### PR TITLE
feat(wine): create single wine endpoint by slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Use `.env.example` as a template:
 ### Wines
 
 - `GET /api/wines` - returns a paginated wine list with optional filters and summarized `pricing.glass` / `pricing.bottle` values
-- `GET /api/wines/:id`
+- `GET /api/wines/:slug`
 - `POST /api/wines`
 - `GET /api/wines/search?q=term`
 - `GET /api/wines/:id/ratings`

--- a/src/controllers/wineController.test.ts
+++ b/src/controllers/wineController.test.ts
@@ -58,7 +58,7 @@ describe("WineController", () => {
   it("listWines returns 200", async () => {
     const wineService = {
       getWines: vi.fn(),
-      getWineById: vi.fn(),
+      getWineBySlug: vi.fn(),
       createWine: vi.fn(),
       searchWines: vi.fn(),
       getWineRatings: vi.fn()
@@ -144,28 +144,28 @@ describe("WineController", () => {
   it("getWine returns 200", async () => {
     const wineService = {
       getWines: vi.fn(),
-      getWineById: vi.fn(),
+      getWineBySlug: vi.fn(),
       createWine: vi.fn(),
       searchWines: vi.fn(),
       getWineRatings: vi.fn()
     } as unknown as WineService;
 
-    vi.mocked(wineService.getWineById).mockResolvedValue(createWineWithInventory());
+    vi.mocked(wineService.getWineBySlug).mockResolvedValue(createWineWithInventory());
 
     const controller = new WineController(wineService);
-    const req = { params: { id: "w1" } } as unknown as Request;
+    const req = { params: { slug: "cabernet-2020" } } as unknown as Request;
     const res = createResponse();
 
     await controller.getWine(req, res);
 
-    expect(wineService.getWineById).toHaveBeenCalledWith("w1");
+    expect(wineService.getWineBySlug).toHaveBeenCalledWith("cabernet-2020");
     expect(res.status).toHaveBeenCalledWith(200);
   });
 
   it("addWine returns 201", async () => {
     const wineService = {
       getWines: vi.fn(),
-      getWineById: vi.fn(),
+      getWineBySlug: vi.fn(),
       createWine: vi.fn(),
       searchWines: vi.fn(),
       getWineRatings: vi.fn()
@@ -186,7 +186,7 @@ describe("WineController", () => {
   it("searchWine returns 200", async () => {
     const wineService = {
       getWines: vi.fn(),
-      getWineById: vi.fn(),
+      getWineBySlug: vi.fn(),
       createWine: vi.fn(),
       searchWines: vi.fn(),
       getWineRatings: vi.fn()
@@ -207,7 +207,7 @@ describe("WineController", () => {
   it("listWineRatings returns 200", async () => {
     const wineService = {
       getWines: vi.fn(),
-      getWineById: vi.fn(),
+      getWineBySlug: vi.fn(),
       createWine: vi.fn(),
       searchWines: vi.fn(),
       getWineRatings: vi.fn()

--- a/src/controllers/wineController.ts
+++ b/src/controllers/wineController.ts
@@ -11,8 +11,8 @@ export class WineController {
   };
 
   public getWine = async (req: Request, res: Response) => {
-    const wineId = req.params.id as string;
-    const wine = await this.wineService.getWineById(wineId);
+    const wineSlug = req.params.slug as string;
+    const wine = await this.wineService.getWineBySlug(wineSlug);
     res.status(200).json(wine);
   };
 

--- a/src/repositories/wine/IWineRepository.ts
+++ b/src/repositories/wine/IWineRepository.ts
@@ -21,6 +21,7 @@ export type WineListFilters = {
 export interface IWineRepository {
   findMany(filters: WineListFilters): Promise<WineWithInventory[]>;
   findByIdWithInventory(id: string): Promise<WineWithInventory | null>;
+  findBySlugWithInventory(slug: string): Promise<WineWithInventory | null>;
   findByUniqueNameWineryVintage(input: {
     name: string;
     wineryId: string;

--- a/src/repositories/wine/WineRepository.test.ts
+++ b/src/repositories/wine/WineRepository.test.ts
@@ -117,6 +117,28 @@ describe("WineRepository", () => {
     });
   });
 
+  it("findBySlugWithInventory requests winery, region, and inventory", async () => {
+    const findUnique = vi.fn().mockResolvedValue(null);
+    const prisma = {
+      wine: {
+        findUnique
+      }
+    } as never;
+
+    const repository = new WineRepository(prisma);
+
+    await repository.findBySlugWithInventory("cabernet-2020");
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { slug: "cabernet-2020" },
+      include: {
+        winery: true,
+        region: true,
+        inventory: true
+      }
+    });
+  });
+
   it("findByUniqueNameWineryVintage queries the compound unique key", async () => {
     const findUnique = vi.fn().mockResolvedValue(null);
     const prisma = {

--- a/src/repositories/wine/WineRepository.ts
+++ b/src/repositories/wine/WineRepository.ts
@@ -31,6 +31,17 @@ export class WineRepository implements IWineRepository {
     });
   }
 
+  public async findBySlugWithInventory(slug: string) {
+    return this.prisma.wine.findUnique({
+      where: { slug },
+      include: {
+        winery: true,
+        region: true,
+        inventory: true
+      }
+    });
+  }
+
   public async findByUniqueNameWineryVintage(input: {
     name: string;
     wineryId: string;

--- a/src/routes/wineRoutes.ts
+++ b/src/routes/wineRoutes.ts
@@ -8,7 +8,7 @@ const router = Router();
 
 router.get("/", validateRequest(listWinesSchema, "query"), asyncHandler(wineController.listWines));
 router.get("/search", validateRequest(searchWineSchema, "query"), asyncHandler(wineController.searchWine));
-router.get("/:id", asyncHandler(wineController.getWine));
+router.get("/:slug", asyncHandler(wineController.getWine));
 router.post("/", validateRequest(createWineSchema), asyncHandler(wineController.addWine));
 router.get("/:id/ratings", asyncHandler(wineController.listWineRatings));
 

--- a/src/services/inventoryService.test.ts
+++ b/src/services/inventoryService.test.ts
@@ -15,6 +15,7 @@ function createService() {
   const wineRepository: IWineRepository = {
     findMany: vi.fn(),
     findByIdWithInventory: vi.fn(),
+    findBySlugWithInventory: vi.fn(),
     findByUniqueNameWineryVintage: vi.fn(),
     create: vi.fn(),
     search: vi.fn()

--- a/src/services/ratingService.test.ts
+++ b/src/services/ratingService.test.ts
@@ -13,6 +13,7 @@ function createService() {
   const wineRepository: IWineRepository = {
     findMany: vi.fn(),
     findByIdWithInventory: vi.fn(),
+    findBySlugWithInventory: vi.fn(),
     findByUniqueNameWineryVintage: vi.fn(),
     create: vi.fn(),
     search: vi.fn()

--- a/src/services/wineService.test.ts
+++ b/src/services/wineService.test.ts
@@ -11,6 +11,7 @@ function createService() {
   const wineRepository: IWineRepository = {
     findMany: vi.fn(),
     findByIdWithInventory: vi.fn(),
+    findBySlugWithInventory: vi.fn(),
     findByUniqueNameWineryVintage: vi.fn(),
     create: vi.fn(),
     search: vi.fn()
@@ -569,21 +570,21 @@ describe("WineService", () => {
     ).toBeGreaterThan(0);
   });
 
-  it("throws when wine by id is missing", async () => {
+  it("throws when wine by slug is missing", async () => {
     const { service, wineRepository } = createService();
 
-    vi.mocked(wineRepository.findByIdWithInventory).mockResolvedValue(null);
+    vi.mocked(wineRepository.findBySlugWithInventory).mockResolvedValue(null);
 
-    await expect(service.getWineById("missing")).rejects.toEqual(new AppError("Wine not found", 404));
+    await expect(service.getWineBySlug("missing-slug")).rejects.toEqual(new AppError("Wine not found", 404));
   });
 
-  it("returns wine by id when present", async () => {
+  it("returns wine by slug when present", async () => {
     const { service, wineRepository } = createService();
     const wine = createWineWithInventory();
 
-    vi.mocked(wineRepository.findByIdWithInventory).mockResolvedValue(wine);
+    vi.mocked(wineRepository.findBySlugWithInventory).mockResolvedValue(wine);
 
-    await expect(service.getWineById("wine-1")).resolves.toEqual(wine);
+    await expect(service.getWineBySlug("cabernet-2020")).resolves.toEqual(wine);
   });
 
   it("creates wine when winery/region exist and duplicate does not", async () => {

--- a/src/services/wineService.ts
+++ b/src/services/wineService.ts
@@ -90,8 +90,8 @@ export class WineService {
     };
   }
 
-  public async getWineById(id: string) {
-    const wine = await this.wineRepository.findByIdWithInventory(id);
+  public async getWineBySlug(slug: string) {
+    const wine = await this.wineRepository.findBySlugWithInventory(slug);
 
     if (!wine) {
       throw new AppError("Wine not found", 404);


### PR DESCRIPTION
## Summary

Implement issue #7 by changing single-wine retrieval to use slug lookup.

## Changes

- add repository contract and implementation support for `findBySlugWithInventory`
- switch wine service single-item lookup from id to slug
- update wine controller to read `req.params.slug`
- change route from `GET /api/wines/:id` to `GET /api/wines/:slug`
- update related controller/service/repository tests and dependent service test doubles
- update README endpoint docs from `:id` to `:slug`

## Verification

- [x] `npm run build`
- [x] `npx prisma validate`
- [x] Relevant endpoint checks completed

## Checklist

- [x] No secrets were added
- [x] README and docs updated (if needed)
- [x] Backward compatibility considered
