### PR TITLE
feat(wine): implement grouping logic by type and region

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Use `.env.example` as a template:
 ### Wines
 
 - `GET /api/wines` - returns a paginated wine list with optional filters and summarized `pricing.glass` / `pricing.bottle` values
+- `GET /api/wines/grouped` - returns wines grouped by inferred type, then by region
 - `GET /api/wines/:slug`
 - `POST /api/wines`
 - `GET /api/wines/search?q=term`
@@ -173,6 +174,48 @@ Example filtered request:
 
 ```text
 GET /api/wines?page=1&pageSize=10&sort=priceGlass&order=asc&country=US&featuredOnly=true
+```
+
+Example `GET /api/wines/grouped` response:
+
+```json
+{
+  "groups": [
+    {
+      "type": "red",
+      "regions": [
+        {
+          "id": "region-1",
+          "name": "Napa Valley",
+          "wines": [
+            {
+              "id": "wine-id",
+              "slug": "cabernet-2020",
+              "name": "Cabernet",
+              "vintage": 2020,
+              "country": "US",
+              "description": "Bold",
+              "imageUrl": "https://example.com/wine.png",
+              "winery": {
+                "id": "winery-1",
+                "name": "Alpha Winery"
+              },
+              "region": {
+                "id": "region-1",
+                "name": "Napa Valley"
+              },
+              "pricing": {
+                "glass": 16,
+                "bottle": 68
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "totalWines": 1
+}
 ```
 
 ### Inventory

--- a/src/controllers/wineController.test.ts
+++ b/src/controllers/wineController.test.ts
@@ -58,6 +58,7 @@ describe("WineController", () => {
   it("listWines returns 200", async () => {
     const wineService = {
       getWines: vi.fn(),
+      getGroupedWines: vi.fn(),
       getWineBySlug: vi.fn(),
       createWine: vi.fn(),
       searchWines: vi.fn(),
@@ -144,6 +145,7 @@ describe("WineController", () => {
   it("getWine returns 200", async () => {
     const wineService = {
       getWines: vi.fn(),
+      getGroupedWines: vi.fn(),
       getWineBySlug: vi.fn(),
       createWine: vi.fn(),
       searchWines: vi.fn(),
@@ -165,6 +167,7 @@ describe("WineController", () => {
   it("addWine returns 201", async () => {
     const wineService = {
       getWines: vi.fn(),
+      getGroupedWines: vi.fn(),
       getWineBySlug: vi.fn(),
       createWine: vi.fn(),
       searchWines: vi.fn(),
@@ -186,6 +189,7 @@ describe("WineController", () => {
   it("searchWine returns 200", async () => {
     const wineService = {
       getWines: vi.fn(),
+      getGroupedWines: vi.fn(),
       getWineBySlug: vi.fn(),
       createWine: vi.fn(),
       searchWines: vi.fn(),
@@ -207,6 +211,7 @@ describe("WineController", () => {
   it("listWineRatings returns 200", async () => {
     const wineService = {
       getWines: vi.fn(),
+      getGroupedWines: vi.fn(),
       getWineBySlug: vi.fn(),
       createWine: vi.fn(),
       searchWines: vi.fn(),
@@ -222,6 +227,64 @@ describe("WineController", () => {
     await controller.listWineRatings(req, res);
 
     expect(wineService.getWineRatings).toHaveBeenCalledWith("w1");
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("listGroupedWines returns 200", async () => {
+    const wineService = {
+      getWines: vi.fn(),
+      getGroupedWines: vi.fn(),
+      getWineBySlug: vi.fn(),
+      createWine: vi.fn(),
+      searchWines: vi.fn(),
+      getWineRatings: vi.fn()
+    } as unknown as WineService;
+
+    vi.mocked(wineService.getGroupedWines).mockResolvedValue({
+      groups: [
+        {
+          type: "red",
+          regions: [
+            {
+              id: "region-1",
+              name: "Napa Valley",
+              wines: [
+                {
+                  id: "w1",
+                  slug: "cabernet-2020",
+                  name: "Cabernet",
+                  vintage: 2020,
+                  country: "US",
+                  description: "Bold",
+                  imageUrl: "https://example.com/wine.png",
+                  winery: {
+                    id: "winery-1",
+                    name: "Alpha Winery"
+                  },
+                  region: {
+                    id: "region-1",
+                    name: "Napa Valley"
+                  },
+                  pricing: {
+                    glass: 16,
+                    bottle: 68
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      totalWines: 1
+    });
+
+    const controller = new WineController(wineService);
+    const res = createResponse();
+    const query = { featuredOnly: true };
+
+    await controller.listGroupedWines({ query } as unknown as Request, res);
+
+    expect(wineService.getGroupedWines).toHaveBeenCalledWith(query);
     expect(res.status).toHaveBeenCalledWith(200);
   });
 });

--- a/src/controllers/wineController.ts
+++ b/src/controllers/wineController.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import type { ListWinesQuery } from "@/services/wineService";
+import type { GroupedWinesQuery, ListWinesQuery } from "@/services/wineService";
 import { WineService } from "@/services/wineService";
 
 export class WineController {
@@ -7,6 +7,11 @@ export class WineController {
 
   public listWines = async (req: Request, res: Response) => {
     const wines = await this.wineService.getWines(req.query as unknown as ListWinesQuery);
+    res.status(200).json(wines);
+  };
+
+  public listGroupedWines = async (req: Request, res: Response) => {
+    const wines = await this.wineService.getGroupedWines(req.query as unknown as GroupedWinesQuery);
     res.status(200).json(wines);
   };
 

--- a/src/models/validation.ts
+++ b/src/models/validation.ts
@@ -7,6 +7,15 @@ const booleanQuerySchema = z
 const wineListSortSchema = z.enum(["createdAt", "name", "priceGlass", "priceBottle"]);
 const sortOrderSchema = z.enum(["asc", "desc"]);
 
+const wineListFilterSchema = z.object({
+  country: z.string().trim().min(1).optional(),
+  regionId: z.string().uuid().optional(),
+  wineryId: z.string().uuid().optional(),
+  featuredOnly: booleanQuerySchema.optional(),
+  hasGlass: booleanQuerySchema.optional(),
+  hasBottle: booleanQuerySchema.optional()
+});
+
 export const registerSchema = z.object({
   email: z.string().email(),
   password: z.string().min(8),
@@ -36,18 +45,14 @@ export const searchWineSchema = z.object({
   q: z.string().min(1)
 });
 
-export const listWinesSchema = z.object({
+export const listWinesSchema = wineListFilterSchema.extend({
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(100).default(20),
   sort: wineListSortSchema.default("createdAt"),
-  order: sortOrderSchema.default("desc"),
-  country: z.string().trim().min(1).optional(),
-  regionId: z.string().uuid().optional(),
-  wineryId: z.string().uuid().optional(),
-  featuredOnly: booleanQuerySchema.optional(),
-  hasGlass: booleanQuerySchema.optional(),
-  hasBottle: booleanQuerySchema.optional()
+  order: sortOrderSchema.default("desc")
 });
+
+export const groupedWinesSchema = wineListFilterSchema;
 
 export const createInventorySchema = z.object({
   wineId: z.string().uuid(),

--- a/src/routes/wineRoutes.test.ts
+++ b/src/routes/wineRoutes.test.ts
@@ -19,4 +19,18 @@ describe("wineRoutes", () => {
       ])
     );
   });
+
+  it("returns 400 for invalid grouped wine query params", async () => {
+    const response = await request(app).get("/api/wines/grouped?regionId=invalid");
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toBe("Validation failed");
+    expect(response.body.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ["regionId"]
+        })
+      ])
+    );
+  });
 });

--- a/src/routes/wineRoutes.ts
+++ b/src/routes/wineRoutes.ts
@@ -1,12 +1,13 @@
 import { Router } from "express";
 import { wineController } from "@/container";
 import { validateRequest } from "@/middleware/validateRequest";
-import { createWineSchema, listWinesSchema, searchWineSchema } from "@/models/validation";
+import { createWineSchema, groupedWinesSchema, listWinesSchema, searchWineSchema } from "@/models/validation";
 import { asyncHandler } from "@/utils/asyncHandler";
 
 const router = Router();
 
 router.get("/", validateRequest(listWinesSchema, "query"), asyncHandler(wineController.listWines));
+router.get("/grouped", validateRequest(groupedWinesSchema, "query"), asyncHandler(wineController.listGroupedWines));
 router.get("/search", validateRequest(searchWineSchema, "query"), asyncHandler(wineController.searchWine));
 router.get("/:slug", asyncHandler(wineController.getWine));
 router.post("/", validateRequest(createWineSchema), asyncHandler(wineController.addWine));

--- a/src/services/wineService.test.ts
+++ b/src/services/wineService.test.ts
@@ -4,7 +4,12 @@ import type { IRegionRepository } from "@/repositories/region/IRegionRepository"
 import type { IRatingRepository } from "@/repositories/rating/IRatingRepository";
 import type { IWineRepository, WineWithInventory } from "@/repositories/wine/IWineRepository";
 import type { IWineryRepository } from "@/repositories/winery/IWineryRepository";
-import { WineService, type CreateWineInput, type ListWinesQuery } from "@/services/wineService";
+import {
+  WineService,
+  type CreateWineInput,
+  type GroupedWinesQuery,
+  type ListWinesQuery
+} from "@/services/wineService";
 import { AppError } from "@/utils/appError";
 
 function createService() {
@@ -95,6 +100,10 @@ const defaultListQuery: ListWinesQuery = {
   pageSize: 20,
   sort: "createdAt",
   order: "desc"
+};
+
+const defaultGroupedQuery: GroupedWinesQuery = {
+  featuredOnly: true
 };
 
 describe("WineService", () => {
@@ -447,6 +456,243 @@ describe("WineService", () => {
       total: 0,
       totalPages: 0
     });
+  });
+
+  it("groups wines by inferred type and region", async () => {
+    const { service, wineRepository } = createService();
+
+    const redWine = createWineWithInventory();
+    redWine.id = "w1";
+    redWine.name = "Cabernet";
+    redWine.region.id = "region-red";
+    redWine.region.name = "Napa Valley";
+    redWine.grapeVarieties = ["Cabernet Sauvignon"];
+    redWine.inventory = [
+      {
+        id: "inv-r",
+        wineId: "w1",
+        locationId: "main",
+        priceGlass: new Decimal(18),
+        priceBottle: new Decimal(72),
+        stockQuantity: 3,
+        isAvailable: true,
+        isFeatured: true,
+        createdAt: new Date("2026-03-19T00:00:00.000Z")
+      }
+    ];
+
+    const whiteWine = createWineWithInventory();
+    whiteWine.id = "w2";
+    whiteWine.name = "Albarino";
+    whiteWine.region.id = "region-white";
+    whiteWine.region.name = "Rias Baixas";
+    whiteWine.grapeVarieties = ["Albarino"];
+    whiteWine.inventory = [
+      {
+        id: "inv-w",
+        wineId: "w2",
+        locationId: "main",
+        priceGlass: new Decimal(15),
+        priceBottle: new Decimal(60),
+        stockQuantity: 5,
+        isAvailable: true,
+        isFeatured: true,
+        createdAt: new Date("2026-03-19T00:00:00.000Z")
+      }
+    ];
+
+    vi.mocked(wineRepository.findMany).mockResolvedValue([whiteWine, redWine]);
+
+    await expect(service.getGroupedWines(defaultGroupedQuery)).resolves.toEqual({
+      groups: [
+        {
+          type: "red",
+          regions: [
+            {
+              id: "region-red",
+              name: "Napa Valley",
+              wines: [
+                {
+                  id: "w1",
+                  slug: "cabernet-2020",
+                  name: "Cabernet",
+                  vintage: 2020,
+                  country: "US",
+                  description: "Bold",
+                  imageUrl: "https://example.com/wine.png",
+                  winery: {
+                    id: "winery-1",
+                    name: "Alpha Winery"
+                  },
+                  region: {
+                    id: "region-red",
+                    name: "Napa Valley"
+                  },
+                  pricing: {
+                    glass: 18,
+                    bottle: 72
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          type: "white",
+          regions: [
+            {
+              id: "region-white",
+              name: "Rias Baixas",
+              wines: [
+                {
+                  id: "w2",
+                  slug: "cabernet-2020",
+                  name: "Albarino",
+                  vintage: 2020,
+                  country: "US",
+                  description: "Bold",
+                  imageUrl: "https://example.com/wine.png",
+                  winery: {
+                    id: "winery-1",
+                    name: "Alpha Winery"
+                  },
+                  region: {
+                    id: "region-white",
+                    name: "Rias Baixas"
+                  },
+                  pricing: {
+                    glass: 15,
+                    bottle: 60
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      totalWines: 2
+    });
+    expect(wineRepository.findMany).toHaveBeenCalledWith({ featuredOnly: true });
+  });
+
+  it("classifies uncategorized wines as other", async () => {
+    const { service, wineRepository } = createService();
+    const wine = createWineWithInventory();
+    wine.name = "Mystery Blend";
+    wine.description = "House selection";
+    wine.grapeVarieties = {
+      primary: "Unknown"
+    } as never;
+
+    vi.mocked(wineRepository.findMany).mockResolvedValue([wine]);
+
+    await expect(service.getGroupedWines({})).resolves.toEqual({
+      groups: [
+        {
+          type: "other",
+          regions: [
+            {
+              id: "region-1",
+              name: "Napa Valley",
+              wines: [
+                {
+                  id: "w1",
+                  slug: "cabernet-2020",
+                  name: "Mystery Blend",
+                  vintage: 2020,
+                  country: "US",
+                  description: "House selection",
+                  imageUrl: "https://example.com/wine.png",
+                  winery: {
+                    id: "winery-1",
+                    name: "Alpha Winery"
+                  },
+                  region: {
+                    id: "region-1",
+                    name: "Napa Valley"
+                  },
+                  pricing: {
+                    glass: null,
+                    bottle: null
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      totalWines: 1
+    });
+  });
+
+  it("classifies sparkling, rose, fortified, and dessert wines", async () => {
+    const { service, wineRepository } = createService();
+
+    const sparklingWine = createWineWithInventory();
+    sparklingWine.id = "w-sparkling";
+    sparklingWine.name = "Prosecco Brut";
+
+    const roseWine = createWineWithInventory();
+    roseWine.id = "w-rose";
+    roseWine.name = "Rose Blend";
+
+    const fortifiedWine = createWineWithInventory();
+    fortifiedWine.id = "w-fortified";
+    fortifiedWine.description = "Classic port style";
+
+    const dessertWine = createWineWithInventory();
+    dessertWine.id = "w-dessert";
+    dessertWine.description = "Late harvest dessert wine";
+
+    vi.mocked(wineRepository.findMany).mockResolvedValue([
+      sparklingWine,
+      roseWine,
+      fortifiedWine,
+      dessertWine
+    ]);
+
+    const response = await service.getGroupedWines({});
+
+    expect(response.totalWines).toBe(4);
+    expect(response.groups.map((group) => group.type)).toEqual([
+      "rose",
+      "sparkling",
+      "dessert",
+      "fortified"
+    ]);
+  });
+
+  it("sorts grouped region names and wine names alphabetically", async () => {
+    const { service, wineRepository } = createService();
+
+    const alphaNapa = createWineWithInventory();
+    alphaNapa.id = "w-alpha";
+    alphaNapa.name = "Alpha Cabernet";
+    alphaNapa.region.id = "region-a";
+    alphaNapa.region.name = "Napa Valley";
+    alphaNapa.grapeVarieties = ["Cabernet Sauvignon"];
+
+    const zetaNapa = createWineWithInventory();
+    zetaNapa.id = "w-zeta";
+    zetaNapa.name = "Zeta Merlot";
+    zetaNapa.region.id = "region-a";
+    zetaNapa.region.name = "Napa Valley";
+    zetaNapa.grapeVarieties = ["Merlot"];
+
+    const betaBordeaux = createWineWithInventory();
+    betaBordeaux.id = "w-beta";
+    betaBordeaux.name = "Beta Cabernet";
+    betaBordeaux.region.id = "region-b";
+    betaBordeaux.region.name = "Bordeaux";
+    betaBordeaux.grapeVarieties = ["Cabernet Sauvignon"];
+
+    vi.mocked(wineRepository.findMany).mockResolvedValue([zetaNapa, betaBordeaux, alphaNapa]);
+
+    const response = await service.getGroupedWines({});
+    const redGroup = response.groups.find((group) => group.type === "red");
+
+    expect(redGroup?.regions.map((region) => region.name)).toEqual(["Bordeaux", "Napa Valley"]);
+    expect(redGroup?.regions[1]?.wines.map((wine) => wine.name)).toEqual(["Alpha Cabernet", "Zeta Merlot"]);
   });
 
   it("covers numeric, string, and nullable comparator branches", () => {

--- a/src/services/wineService.ts
+++ b/src/services/wineService.ts
@@ -26,6 +26,24 @@ export type WineListItem = {
   };
 };
 
+export type WineType = "red" | "white" | "rose" | "sparkling" | "dessert" | "fortified" | "other";
+
+export type GroupedWineRegion = {
+  id: string;
+  name: string;
+  wines: WineListItem[];
+};
+
+export type GroupedWineType = {
+  type: WineType;
+  regions: GroupedWineRegion[];
+};
+
+export type GroupedWinesResponse = {
+  groups: GroupedWineType[];
+  totalWines: number;
+};
+
 export type WineListSort = "createdAt" | "name" | "priceGlass" | "priceBottle";
 
 export type SortOrder = "asc" | "desc";
@@ -36,6 +54,8 @@ export type ListWinesQuery = WineListFilters & {
   sort: WineListSort;
   order: SortOrder;
 };
+
+export type GroupedWinesQuery = WineListFilters;
 
 export type PaginatedWineList = {
   items: WineListItem[];
@@ -90,6 +110,48 @@ export class WineService {
     };
   }
 
+  public async getGroupedWines(query: GroupedWinesQuery): Promise<GroupedWinesResponse> {
+    const wines = await this.wineRepository.findMany(this.toWineListFilters(query));
+    const groupedByType = new Map<WineType, Map<string, GroupedWineRegion>>();
+
+    for (const wine of wines) {
+      const wineType = this.inferWineType(wine);
+      const regionMap = groupedByType.get(wineType) ?? new Map<string, GroupedWineRegion>();
+      const region = regionMap.get(wine.region.id) ?? {
+        id: wine.region.id,
+        name: wine.region.name,
+        wines: []
+      };
+
+      region.wines.push(this.toWineListItem(wine));
+      regionMap.set(wine.region.id, region);
+      groupedByType.set(wineType, regionMap);
+    }
+
+    const typeOrder: WineType[] = ["red", "white", "rose", "sparkling", "dessert", "fortified", "other"];
+    const groups = typeOrder.flatMap((wineType) => {
+      const regionMap = groupedByType.get(wineType);
+
+      if (!regionMap) {
+        return [];
+      }
+
+      const regions = [...regionMap.values()]
+        .map((region) => ({
+          ...region,
+          wines: region.wines.sort((left, right) => left.name.localeCompare(right.name))
+        }))
+        .sort((left, right) => left.name.localeCompare(right.name));
+
+      return [{ type: wineType, regions }];
+    });
+
+    return {
+      groups,
+      totalWines: wines.length
+    };
+  }
+
   public async getWineBySlug(slug: string) {
     const wine = await this.wineRepository.findBySlugWithInventory(slug);
 
@@ -139,7 +201,7 @@ export class WineService {
     return this.ratingRepository.findByWineId(wineId);
   }
 
-  private toWineListFilters(query: ListWinesQuery): WineListFilters {
+  private toWineListFilters(query: ListWinesQuery | GroupedWinesQuery): WineListFilters {
     return {
       ...(query.country !== undefined ? { country: query.country } : {}),
       ...(query.regionId !== undefined ? { regionId: query.regionId } : {}),
@@ -148,6 +210,43 @@ export class WineService {
       ...(query.hasGlass !== undefined ? { hasGlass: query.hasGlass } : {}),
       ...(query.hasBottle !== undefined ? { hasBottle: query.hasBottle } : {})
     };
+  }
+
+  private inferWineType(wine: WineWithInventory): WineType {
+    const grapeVarieties = Array.isArray(wine.grapeVarieties)
+      ? wine.grapeVarieties.filter((value): value is string => typeof value === "string")
+      : [];
+    const searchableText = [wine.name, wine.description, ...grapeVarieties].join(" ").toLowerCase();
+
+    if (this.matchesAny(searchableText, ["sparkling", "champagne", "prosecco", "cava"])) {
+      return "sparkling";
+    }
+
+    if (this.matchesAny(searchableText, ["rose", "rosé"])) {
+      return "rose";
+    }
+
+    if (this.matchesAny(searchableText, ["port", "sherry", "madeira"])) {
+      return "fortified";
+    }
+
+    if (this.matchesAny(searchableText, ["sauternes", "ice wine", "late harvest", "tokaji", "dessert"])) {
+      return "dessert";
+    }
+
+    if (this.matchesAny(searchableText, ["chardonnay", "sauvignon blanc", "pinot grigio", "riesling", "chenin", "albarino"])) {
+      return "white";
+    }
+
+    if (this.matchesAny(searchableText, ["cabernet", "merlot", "pinot noir", "syrah", "shiraz", "malbec", "tempranillo", "zinfandel"])) {
+      return "red";
+    }
+
+    return "other";
+  }
+
+  private matchesAny(searchableText: string, candidates: string[]) {
+    return candidates.some((candidate) => searchableText.includes(candidate));
   }
 
   private compareWineListItems(


### PR DESCRIPTION
## Summary

Implement issue #8 by adding a grouped wine response for menu display.

Closes #8

## Changes

- add grouped wines endpoint at `GET /api/wines/grouped`
- group wines by inferred type and then by region
- keep existing list and single-wine endpoints unchanged
- add query validation support for grouped endpoint filters
- add unit tests for grouped controller/service behavior and route validation
- update README endpoint documentation with grouped response example

## Verification

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npx prisma validate`
- [x] Relevant endpoint checks completed

## Checklist

- [x] No secrets were added
- [x] README and docs updated (if needed)
- [x] Backward compatibility considered
