### PR TITLE
[FEATURE] Implement slug generation for wines

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Use `.env.example` as a template:
 - `GET /api/wines` - returns a paginated wine list with optional filters and summarized `pricing.glass` / `pricing.bottle` values
 - `GET /api/wines/grouped` - returns wines grouped by inferred type, then by region
 - `GET /api/wines/:slug`
-- `POST /api/wines`
+- `POST /api/wines` - creates a wine and generates its slug from `name` + `vintage`
 - `GET /api/wines/search?q=term`
 - `GET /api/wines/:id/ratings`
 
@@ -217,6 +217,24 @@ Example `GET /api/wines/grouped` response:
   "totalWines": 1
 }
 ```
+
+Example `POST /api/wines` request body:
+
+```json
+{
+  "name": "Opus One",
+  "vintage": 2019,
+  "wineryId": "winery-id",
+  "regionId": "region-id",
+  "country": "US",
+  "grapeVarieties": ["Cabernet Sauvignon", "Merlot"],
+  "alcoholPercent": 14.5,
+  "description": "Structured and age-worthy.",
+  "imageUrl": "https://example.com/opus-one.png"
+}
+```
+
+Generated slugs are based on `name` + `vintage` and receive a numeric suffix when needed to stay unique, for example `opus-one-2019` or `opus-one-2019-2`.
 
 ### Inventory
 

--- a/src/models/validation.test.ts
+++ b/src/models/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { listWinesSchema } from "@/models/validation";
+import { createWineSchema, listWinesSchema } from "@/models/validation";
 
 describe("listWinesSchema", () => {
   it("applies defaults and transforms string booleans", () => {
@@ -21,6 +21,61 @@ describe("listWinesSchema", () => {
       order: "desc",
       hasBottle: true,
       featuredOnly: false
+    });
+  });
+});
+
+describe("createWineSchema", () => {
+  it("accepts a create payload without a slug", () => {
+    expect(
+      createWineSchema.parse({
+        name: "Cabernet",
+        vintage: 2020,
+        wineryId: "11111111-1111-4111-8111-111111111111",
+        regionId: "22222222-2222-4222-8222-222222222222",
+        country: "US",
+        grapeVarieties: ["Cabernet Sauvignon"],
+        alcoholPercent: 13.5,
+        description: "Bold",
+        imageUrl: "https://example.com/wine.png"
+      })
+    ).toEqual({
+      name: "Cabernet",
+      vintage: 2020,
+      wineryId: "11111111-1111-4111-8111-111111111111",
+      regionId: "22222222-2222-4222-8222-222222222222",
+      country: "US",
+      grapeVarieties: ["Cabernet Sauvignon"],
+      alcoholPercent: 13.5,
+      description: "Bold",
+      imageUrl: "https://example.com/wine.png"
+    });
+  });
+
+  it("strips a client-provided slug from the payload", () => {
+    expect(
+      createWineSchema.parse({
+        name: "Cabernet",
+        slug: "ignored-by-server",
+        vintage: 2020,
+        wineryId: "11111111-1111-4111-8111-111111111111",
+        regionId: "22222222-2222-4222-8222-222222222222",
+        country: "US",
+        grapeVarieties: ["Cabernet Sauvignon"],
+        alcoholPercent: 13.5,
+        description: "Bold",
+        imageUrl: "https://example.com/wine.png"
+      })
+    ).toEqual({
+      name: "Cabernet",
+      vintage: 2020,
+      wineryId: "11111111-1111-4111-8111-111111111111",
+      regionId: "22222222-2222-4222-8222-222222222222",
+      country: "US",
+      grapeVarieties: ["Cabernet Sauvignon"],
+      alcoholPercent: 13.5,
+      description: "Bold",
+      imageUrl: "https://example.com/wine.png"
     });
   });
 });

--- a/src/models/validation.ts
+++ b/src/models/validation.ts
@@ -29,7 +29,6 @@ export const loginSchema = z.object({
 
 export const createWineSchema = z.object({
   name: z.string().min(1),
-  slug: z.string().min(1),
   vintage: z.number().int().min(1900).max(2100),
   wineryId: z.string().uuid(),
   regionId: z.string().uuid(),

--- a/src/repositories/wine/IWineRepository.ts
+++ b/src/repositories/wine/IWineRepository.ts
@@ -20,6 +20,7 @@ export type WineListFilters = {
 
 export interface IWineRepository {
   findMany(filters: WineListFilters): Promise<WineWithInventory[]>;
+  findBySlug(slug: string): Promise<Wine | null>;
   findByIdWithInventory(id: string): Promise<WineWithInventory | null>;
   findBySlugWithInventory(slug: string): Promise<WineWithInventory | null>;
   findByUniqueNameWineryVintage(input: {

--- a/src/repositories/wine/WineRepository.test.ts
+++ b/src/repositories/wine/WineRepository.test.ts
@@ -117,6 +117,23 @@ describe("WineRepository", () => {
     });
   });
 
+  it("findBySlug queries the unique slug", async () => {
+    const findUnique = vi.fn().mockResolvedValue(null);
+    const prisma = {
+      wine: {
+        findUnique
+      }
+    } as never;
+
+    const repository = new WineRepository(prisma);
+
+    await repository.findBySlug("cabernet-2020");
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { slug: "cabernet-2020" }
+    });
+  });
+
   it("findBySlugWithInventory requests winery, region, and inventory", async () => {
     const findUnique = vi.fn().mockResolvedValue(null);
     const prisma = {

--- a/src/repositories/wine/WineRepository.ts
+++ b/src/repositories/wine/WineRepository.ts
@@ -31,6 +31,12 @@ export class WineRepository implements IWineRepository {
     });
   }
 
+  public async findBySlug(slug: string) {
+    return this.prisma.wine.findUnique({
+      where: { slug }
+    });
+  }
+
   public async findBySlugWithInventory(slug: string) {
     return this.prisma.wine.findUnique({
       where: { slug },

--- a/src/services/inventoryService.test.ts
+++ b/src/services/inventoryService.test.ts
@@ -14,6 +14,7 @@ function createService() {
 
   const wineRepository: IWineRepository = {
     findMany: vi.fn(),
+    findBySlug: vi.fn(),
     findByIdWithInventory: vi.fn(),
     findBySlugWithInventory: vi.fn(),
     findByUniqueNameWineryVintage: vi.fn(),

--- a/src/services/ratingService.test.ts
+++ b/src/services/ratingService.test.ts
@@ -12,6 +12,7 @@ function createService() {
 
   const wineRepository: IWineRepository = {
     findMany: vi.fn(),
+    findBySlug: vi.fn(),
     findByIdWithInventory: vi.fn(),
     findBySlugWithInventory: vi.fn(),
     findByUniqueNameWineryVintage: vi.fn(),

--- a/src/services/wineService.test.ts
+++ b/src/services/wineService.test.ts
@@ -15,6 +15,7 @@ import { AppError } from "@/utils/appError";
 function createService() {
   const wineRepository: IWineRepository = {
     findMany: vi.fn(),
+    findBySlug: vi.fn(),
     findByIdWithInventory: vi.fn(),
     findBySlugWithInventory: vi.fn(),
     findByUniqueNameWineryVintage: vi.fn(),
@@ -46,7 +47,6 @@ function createService() {
 
 const input: CreateWineInput = {
   name: "Cabernet",
-  slug: "cabernet-winery-1-2020",
   vintage: 2020,
   wineryId: "winery-1",
   regionId: "region-1",
@@ -840,10 +840,57 @@ describe("WineService", () => {
     vi.mocked(wineryRepository.findById).mockResolvedValue({ id: "winery-1" } as never);
     vi.mocked(regionRepository.findById).mockResolvedValue({ id: "region-1" } as never);
     vi.mocked(wineRepository.findByUniqueNameWineryVintage).mockResolvedValue(null);
+    vi.mocked(wineRepository.findBySlug).mockResolvedValue(null);
     vi.mocked(wineRepository.create).mockResolvedValue(created);
 
     await expect(service.createWine(input)).resolves.toEqual(created);
-    expect(wineRepository.create).toHaveBeenCalledWith(input);
+    expect(wineRepository.create).toHaveBeenCalledWith({
+      ...input,
+      slug: "cabernet-2020"
+    });
+  });
+
+  it("adds a numeric suffix when the generated slug already exists", async () => {
+    const { service, wineRepository, wineryRepository, regionRepository } = createService();
+    const created = createWineWithRelations();
+
+    vi.mocked(wineryRepository.findById).mockResolvedValue({ id: "winery-1" } as never);
+    vi.mocked(regionRepository.findById).mockResolvedValue({ id: "region-1" } as never);
+    vi.mocked(wineRepository.findByUniqueNameWineryVintage).mockResolvedValue(null);
+    vi.mocked(wineRepository.findBySlug)
+      .mockResolvedValueOnce({ id: "existing-1" } as never)
+      .mockResolvedValueOnce({ id: "existing-2" } as never)
+      .mockResolvedValueOnce(null);
+    vi.mocked(wineRepository.create).mockResolvedValue(created);
+
+    await service.createWine(input);
+
+    expect(wineRepository.create).toHaveBeenCalledWith({
+      ...input,
+      slug: "cabernet-2020-3"
+    });
+  });
+
+  it("falls back to a generic slug prefix when name normalization is empty", async () => {
+    const { service, wineRepository, wineryRepository, regionRepository } = createService();
+    const created = createWineWithRelations();
+
+    vi.mocked(wineryRepository.findById).mockResolvedValue({ id: "winery-1" } as never);
+    vi.mocked(regionRepository.findById).mockResolvedValue({ id: "region-1" } as never);
+    vi.mocked(wineRepository.findByUniqueNameWineryVintage).mockResolvedValue(null);
+    vi.mocked(wineRepository.findBySlug).mockResolvedValue(null);
+    vi.mocked(wineRepository.create).mockResolvedValue(created);
+
+    await service.createWine({
+      ...input,
+      name: "!!!"
+    });
+
+    expect(wineRepository.create).toHaveBeenCalledWith({
+      ...input,
+      name: "!!!",
+      slug: "wine-2020"
+    });
   });
 
   it("throws when winery is missing", async () => {

--- a/src/services/wineService.ts
+++ b/src/services/wineService.ts
@@ -67,7 +67,6 @@ export type PaginatedWineList = {
 
 export type CreateWineInput = {
   name: string;
-  slug: string;
   vintage: number;
   wineryId: string;
   regionId: string;
@@ -184,7 +183,10 @@ export class WineService {
       throw new AppError("Wine with the same name, winery, and vintage already exists", 409);
     }
 
-    return this.wineRepository.create(input);
+    return this.wineRepository.create({
+      ...input,
+      slug: await this.generateUniqueSlug(input.name, input.vintage)
+    });
   }
 
   public async searchWines(query: string) {
@@ -210,6 +212,32 @@ export class WineService {
       ...(query.hasGlass !== undefined ? { hasGlass: query.hasGlass } : {}),
       ...(query.hasBottle !== undefined ? { hasBottle: query.hasBottle } : {})
     };
+  }
+
+  private async generateUniqueSlug(name: string, vintage: number): Promise<string> {
+    const normalizedName = this.slugify(name);
+    const baseSlug = normalizedName ? `${normalizedName}-${vintage}` : `wine-${vintage}`;
+    let candidateSlug = baseSlug;
+    let suffix = 2;
+
+    while (await this.wineRepository.findBySlug(candidateSlug)) {
+      candidateSlug = `${baseSlug}-${suffix}`;
+      suffix += 1;
+    }
+
+    return candidateSlug;
+  }
+
+  private slugify(value: string): string {
+    return value
+      .normalize("NFKD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-+|-+$/g, "");
   }
 
   private inferWineType(wine: WineWithInventory): WineType {


### PR DESCRIPTION
## Summary
- generate wine slugs in the service from normalized name plus vintage
- ensure generated slugs stay unique by checking existing slugs and appending numeric suffixes
- update validation and docs so POST /api/wines no longer accepts a client-managed slug

## Testing
- npm run build
- npm run test
- npm run test:coverage
- npx prisma validate

Closes #11