### PR TITLE
feat: map Square variations to wine_variations

### DIFF
--- a/src/integrations/square/squareWineSyncService.test.ts
+++ b/src/integrations/square/squareWineSyncService.test.ts
@@ -32,6 +32,7 @@ describe("SquareWineSyncService", () => {
             {
               id: "square-var-1",
               itemVariationData: {
+                name: "5oz",
                 priceMoney: {
                   amount: 1500
                 }
@@ -40,6 +41,7 @@ describe("SquareWineSyncService", () => {
             {
               id: "square-var-2",
               itemVariationData: {
+                name: "9oz",
                 priceMoney: {
                   amount: 1800
                 }
@@ -65,8 +67,11 @@ describe("SquareWineSyncService", () => {
     expect(repository.replaceInventoryForWine).toHaveBeenCalledWith("wine-created", [
       {
         squareVariationId: "square-var-1",
-        variationName: "Square Variation square-var-1",
+        variationName: "5oz",
         price: 15,
+        volumeOz: 5,
+        isPublic: true,
+        isDefault: false,
         locationId: "square:square-var-1",
         stockQuantity: 0,
         isAvailable: true,
@@ -74,8 +79,11 @@ describe("SquareWineSyncService", () => {
       },
       {
         squareVariationId: "square-var-2",
-        variationName: "Square Variation square-var-2",
+        variationName: "9oz",
         price: 18,
+        volumeOz: 9,
+        isPublic: true,
+        isDefault: true,
         locationId: "square:square-var-2",
         stockQuantity: 0,
         isAvailable: false,
@@ -122,6 +130,7 @@ describe("SquareWineSyncService", () => {
             {
               id: "dup-var",
               itemVariationData: {
+                name: "8oz",
                 priceMoney: {
                   amount: 1200
                 }
@@ -135,6 +144,7 @@ describe("SquareWineSyncService", () => {
         id: "dup-var",
         itemVariationData: {
           itemId: "square-item-dedupe",
+          name: "8oz",
           priceMoney: {
             amount: 1200
           }
@@ -160,8 +170,11 @@ describe("SquareWineSyncService", () => {
     expect(firstCallRows).toEqual([
       {
         squareVariationId: "dup-var",
-        variationName: "Square Variation dup-var",
+        variationName: "8oz",
         price: 12,
+        volumeOz: 8,
+        isPublic: true,
+        isDefault: false,
         locationId: "square:dup-var",
         stockQuantity: 0,
         isAvailable: true,
@@ -174,6 +187,8 @@ describe("SquareWineSyncService", () => {
         squareVariationId: "square-item-no-variation-default",
         variationName: "Square Variation square-item-no-variation-default",
         price: 0,
+        isPublic: true,
+        isDefault: false,
         locationId: "square:square-item-no-variation-default",
         stockQuantity: 0,
         isAvailable: true,
@@ -294,7 +309,73 @@ describe("SquareWineSyncService", () => {
         squareVariationId: "square-item-punct-variation",
         variationName: "Square Variation square-item-punct-variation",
         price: 0,
+        isPublic: true,
+        isDefault: false,
         locationId: "square:square-item-punct-variation",
+        stockQuantity: 0,
+        isAvailable: true,
+        isFeatured: false
+      }
+    ]);
+  });
+
+  it("marks 2oz variations as private and 9oz as default", async () => {
+    const repository = createSquareSyncRepositoryMock();
+    const service = new SquareWineSyncService(repository);
+
+    const catalogObjects = [
+      {
+        type: "ITEM",
+        id: "square-item-serving-rules",
+        itemData: {
+          name: "Serving Rules Wine",
+          variations: [
+            {
+              id: "var-2oz",
+              itemVariationData: {
+                name: "2oz",
+                priceMoney: {
+                  amount: 900
+                }
+              }
+            },
+            {
+              id: "var-9oz",
+              itemVariationData: {
+                name: "9oz",
+                priceMoney: {
+                  amount: 2500
+                }
+              }
+            }
+          ]
+        }
+      }
+    ] as never[];
+
+    await service.syncCatalogObjects(catalogObjects);
+
+    expect(repository.replaceInventoryForWine).toHaveBeenCalledWith("wine-created", [
+      {
+        squareVariationId: "var-2oz",
+        variationName: "2oz",
+        price: 9,
+        volumeOz: 2,
+        isPublic: false,
+        isDefault: false,
+        locationId: "square:var-2oz",
+        stockQuantity: 0,
+        isAvailable: true,
+        isFeatured: false
+      },
+      {
+        squareVariationId: "var-9oz",
+        variationName: "9oz",
+        price: 25,
+        volumeOz: 9,
+        isPublic: true,
+        isDefault: true,
+        locationId: "square:var-9oz",
         stockQuantity: 0,
         isAvailable: true,
         isFeatured: false

--- a/src/integrations/square/squareWineSyncService.ts
+++ b/src/integrations/square/squareWineSyncService.ts
@@ -18,6 +18,7 @@ type ParsedSquareItem = {
 
 type ParsedSquareVariation = {
   id: string;
+  name: string;
   priceAmountCents: number;
   isDeleted: boolean;
 };
@@ -99,9 +100,14 @@ export class SquareWineSyncService {
           const variationId = this.readString(variation.id) ?? `${object.id}-variation`;
           const itemVariationData = (variation.itemVariationData ?? {}) as Record<string, unknown>;
           const priceMoney = (itemVariationData.priceMoney ?? {}) as Record<string, unknown>;
+          const variationName =
+            this.readString(itemVariationData.name) ??
+            this.readString(variation.name) ??
+            `Square Variation ${variationId}`;
           const current = variationsByItemId.get(object.id) ?? [];
           current.push({
             id: variationId,
+            name: variationName,
             priceAmountCents: this.readNumber(priceMoney.amount),
             isDeleted: this.readBoolean(variation.isDeleted)
           });
@@ -116,8 +122,12 @@ export class SquareWineSyncService {
         }
 
         const current = variationsByItemId.get(itemId) ?? [];
+        const variationName =
+          this.readString(object.itemVariationData?.name) ??
+          `Square Variation ${object.id ?? `${itemId}-variation`}`;
         current.push({
           id: object.id ?? `${itemId}-variation`,
+          name: variationName,
           priceAmountCents: Number(object.itemVariationData?.priceMoney?.amount ?? 0),
           isDeleted: object.isDeleted ?? false
         });
@@ -170,21 +180,47 @@ export class SquareWineSyncService {
   }
 
   private mapVariationsToInventoryRows(variations: ParsedSquareVariation[], itemId: string): InventorySyncRow[] {
-    const source = variations.length > 0 ? variations : [{ id: `${itemId}-default`, priceAmountCents: 0, isDeleted: false }];
+    const source =
+      variations.length > 0
+        ? variations
+        : [
+          {
+            id: `${itemId}-default`,
+            name: `Square Variation ${itemId}-default`,
+            priceAmountCents: 0,
+            isDeleted: false
+          }
+        ];
 
     return source.map((variation) => {
       const price = variation.priceAmountCents > 0 ? variation.priceAmountCents / 100 : 0;
+      const volumeOz = this.parseVolumeOz(variation.name);
+      const isTwoOz = volumeOz === 2;
+      const isNineOz = volumeOz === 9;
 
       return {
         squareVariationId: variation.id,
-        variationName: `Square Variation ${variation.id}`,
+        variationName: variation.name,
         price,
+        ...(volumeOz !== null ? { volumeOz } : {}),
+        isPublic: !isTwoOz,
+        isDefault: isNineOz,
         locationId: `square:${variation.id}`,
         stockQuantity: 0,
         isAvailable: !variation.isDeleted,
         isFeatured: false
       };
     });
+  }
+
+  private parseVolumeOz(name: string): number | null {
+    const normalized = name.trim().toLowerCase();
+    const match = normalized.match(/(\d+(?:\.\d+)?)\s*oz\b/);
+    if (!match) {
+      return null;
+    }
+
+    return Math.round(Number(match[1]));
   }
 
   private buildSlug(name: string, squareItemId: string): string {

--- a/src/repositories/squareSync/ISquareSyncRepository.ts
+++ b/src/repositories/squareSync/ISquareSyncRepository.ts
@@ -5,6 +5,8 @@ export type InventorySyncRow = {
   variationName: string;
   price: number;
   volumeOz?: number;
+  isPublic?: boolean;
+  isDefault?: boolean;
   locationId: string;
   stockQuantity: number;
   isAvailable: boolean;

--- a/src/repositories/squareSync/SquareSyncRepository.ts
+++ b/src/repositories/squareSync/SquareSyncRepository.ts
@@ -84,10 +84,15 @@ export class SquareSyncRepository implements ISquareSyncRepository {
         }
       });
       const variationRows = Array.from(variationMap.values());
+      const defaultVariationRow = variationRows.find((row) => row.isDefault);
+      const fallbackDefaultRow = variationRows.find((row) => row.isPublic ?? true) ?? variationRows[0];
+      const selectedDefaultKey =
+        (defaultVariationRow?.squareVariationId || defaultVariationRow?.variationName) ??
+        (fallbackDefaultRow?.squareVariationId || fallbackDefaultRow?.variationName);
 
       // Create variations first
       const variations = await Promise.all(
-        variationRows.map((row, index) =>
+        variationRows.map((row) =>
           tx.wineVariation.create({
             data: {
               wineId,
@@ -95,8 +100,8 @@ export class SquareSyncRepository implements ISquareSyncRepository {
               name: row.variationName,
               price: row.price,
               volumeOz: row.volumeOz ?? null,
-              isPublic: true,
-              isDefault: index === 0
+              isPublic: row.isPublic ?? true,
+              isDefault: (row.squareVariationId || row.variationName) === selectedDefaultKey
             }
           })
         )


### PR DESCRIPTION
## Issues

Closes #16

## Summary

Map Square item variations into `wine_variations` with serving-size aware metadata so sync writes correct variation name, price, visibility, and default selection.

## Changes

- Parse variation names from Square `ITEM` and `ITEM_VARIATION` payloads and map to `variationName`
- Parse serving size (`volumeOz`) from variation names like `2oz`, `5oz`, `9oz`
- Apply business rules during mapping:
- 2oz variations are marked `isPublic = false`
- 9oz variations are marked `isDefault = true`
- Extend `InventorySyncRow` contract with optional `isPublic` and `isDefault`
- Persist mapped `isPublic`/`isDefault` in `SquareSyncRepository` when creating `wine_variations`
- Keep sync idempotent by replacing existing variations/inventory for each wine before insert
- Add and update tests for new variation mapping and serving-size rules

## Verification

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npx prisma validate`
- [x] Relevant endpoint checks completed

## Checklist

- [x] No secrets were added
- [x] README and docs updated (if needed)
- [x] Backward compatibility considered
