### PR TITLE
feat(Issue #40): Model serving modes for bottle and glass offerings

### DIFF
--- a/prisma/migrations/20260323153800_issue40_serving_modes/migration.sql
+++ b/prisma/migrations/20260323153800_issue40_serving_modes/migration.sql
@@ -1,0 +1,37 @@
+-- CreateEnum
+CREATE TYPE "public"."ServingMode" AS ENUM ('BOTTLE_750ML', 'GLASS_5OZ', 'GLASS_9OZ', 'FLIGHT_2OZ', 'UNKNOWN');
+
+-- CreateTable
+CREATE TABLE "public"."WineVariationServingMode" (
+    "id" TEXT NOT NULL,
+    "wineVariationId" TEXT NOT NULL,
+    "servingMode" "public"."ServingMode" NOT NULL DEFAULT 'UNKNOWN',
+    "isAvailable" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WineVariationServingMode_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."SquareServingModeOverride" (
+    "id" TEXT NOT NULL,
+    "squareVariationId" TEXT NOT NULL,
+    "servingMode" "public"."ServingMode" NOT NULL,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SquareServingModeOverride_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WineVariationServingMode_wineVariationId_key" ON "public"."WineVariationServingMode"("wineVariationId");
+
+-- CreateIndex
+CREATE INDEX "WineVariationServingMode_servingMode_isAvailable_idx" ON "public"."WineVariationServingMode"("servingMode", "isAvailable");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SquareServingModeOverride_squareVariationId_key" ON "public"."SquareServingModeOverride"("squareVariationId");
+
+-- AddForeignKey
+ALTER TABLE "public"."WineVariationServingMode" ADD CONSTRAINT "WineVariationServingMode_wineVariationId_fkey" FOREIGN KEY ("wineVariationId") REFERENCES "public"."WineVariation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,14 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum ServingMode {
+  BOTTLE_750ML
+  GLASS_5OZ
+  GLASS_9OZ
+  FLIGHT_2OZ
+  UNKNOWN
+}
+
 model Wine {
   id             String      @id @default(uuid())
   name           String
@@ -47,9 +55,30 @@ model WineVariation {
 
   wine      Wine        @relation(fields: [wineId], references: [id], onDelete: Cascade)
   squareCatalogVariation SquareCatalogVariation?
+  servingModeConfig WineVariationServingMode?
 
   @@index([wineId])
   @@index([squareVariationId])
+}
+
+model WineVariationServingMode {
+  id              String      @id @default(uuid())
+  wineVariationId String      @unique
+  servingMode     ServingMode @default(UNKNOWN)
+  isAvailable     Boolean     @default(true)
+  createdAt       DateTime    @default(now())
+
+  wineVariation   WineVariation @relation(fields: [wineVariationId], references: [id], onDelete: Cascade)
+
+  @@index([servingMode, isAvailable])
+}
+
+model SquareServingModeOverride {
+  id                String      @id @default(uuid())
+  squareVariationId String      @unique
+  servingMode       ServingMode
+  notes             String?
+  createdAt         DateTime    @default(now())
 }
 
 model SquareCatalogItem {

--- a/src/integrations/square/squareCatalogParser.ts
+++ b/src/integrations/square/squareCatalogParser.ts
@@ -1,4 +1,5 @@
 import type { CatalogObject } from "square";
+import type { ServingMode } from "@prisma/client";
 import type { InventorySyncRow } from "@/repositories/squareSync/ISquareSyncRepository";
 
 export type ParsedSquareItem = {
@@ -88,7 +89,11 @@ export class SquareCatalogParser {
     return parsedItems;
   }
 
-  public mapVariationsToInventoryRows(variations: ParsedSquareItem["variations"], itemId: string): InventorySyncRow[] {
+  public mapVariationsToInventoryRows(
+    variations: ParsedSquareItem["variations"],
+    itemId: string,
+    servingModeOverrides: Record<string, ServingMode> = {}
+  ): InventorySyncRow[] {
     const source =
       variations.length > 0
         ? variations
@@ -104,15 +109,18 @@ export class SquareCatalogParser {
     return source.map((variation) => {
       const price = variation.priceAmountCents > 0 ? variation.priceAmountCents / 100 : 0;
       const volumeOz = this.parseVolumeOz(variation.name);
-      const isTwoOz = volumeOz === 2;
-      const isNineOz = volumeOz === 9;
+      const servingMode =
+        servingModeOverrides[variation.id] ?? this.inferServingMode(variation.name, volumeOz);
+      const isFlightPour = servingMode === "FLIGHT_2OZ";
+      const isNineOz = servingMode === "GLASS_9OZ";
 
       return {
         squareVariationId: variation.id,
         variationName: variation.name,
+        servingMode,
         price,
         ...(volumeOz !== null ? { volumeOz } : {}),
-        isPublic: !isTwoOz,
+        isPublic: !isFlightPour,
         isDefault: isNineOz,
         locationId: `square:${variation.id}`,
         sealedBottleCount: 0,
@@ -159,5 +167,27 @@ export class SquareCatalogParser {
     }
 
     return Math.round(Number(match[1]));
+  }
+
+  private inferServingMode(name: string, volumeOz: number | null): ServingMode {
+    const normalized = name.trim().toLowerCase();
+
+    if (normalized.includes("750ml") || normalized.includes("bottle")) {
+      return "BOTTLE_750ML";
+    }
+
+    if (normalized.includes("flight") || volumeOz === 2) {
+      return "FLIGHT_2OZ";
+    }
+
+    if (volumeOz === 5) {
+      return "GLASS_5OZ";
+    }
+
+    if (volumeOz === 9) {
+      return "GLASS_9OZ";
+    }
+
+    return "UNKNOWN";
   }
 }

--- a/src/integrations/square/squareWineSyncService.test.ts
+++ b/src/integrations/square/squareWineSyncService.test.ts
@@ -18,6 +18,7 @@ function createSquareSyncRepositoryMock(): ISquareSyncRepository {
     updateWineSquareFieldsBySquareItemId: vi.fn().mockResolvedValue({ id: "wine-updated" } as Wine),
     upsertSquareCatalogItem: vi.fn().mockResolvedValue({ id: "square-catalog-item-1" }),
     upsertSquareCatalogVariation: vi.fn().mockResolvedValue(undefined),
+    findServingModeOverrides: vi.fn().mockResolvedValue({}),
     replaceInventoryForWine: vi.fn().mockImplementation(async (_wineId: string, rows: InventorySyncRow[]) => rows.length),
     findWineVariationsBySquareVariationIds: vi.fn().mockResolvedValue([] as WineVariationKey[])
   };
@@ -75,6 +76,7 @@ describe("SquareWineSyncService", () => {
       {
         squareVariationId: "square-var-1",
         variationName: "5oz",
+        servingMode: "GLASS_5OZ",
         price: 15,
         volumeOz: 5,
         isPublic: true,
@@ -87,6 +89,7 @@ describe("SquareWineSyncService", () => {
       {
         squareVariationId: "square-var-2",
         variationName: "9oz",
+        servingMode: "GLASS_9OZ",
         price: 18,
         volumeOz: 9,
         isPublic: true,
@@ -182,6 +185,7 @@ describe("SquareWineSyncService", () => {
       {
         squareVariationId: "dup-var",
         variationName: "8oz",
+        servingMode: "UNKNOWN",
         price: 12,
         volumeOz: 8,
         isPublic: true,
@@ -197,6 +201,7 @@ describe("SquareWineSyncService", () => {
       {
         squareVariationId: "square-item-no-variation-default",
         variationName: "Square Variation square-item-no-variation-default",
+        servingMode: "UNKNOWN",
         price: 0,
         isPublic: true,
         isDefault: false,
@@ -364,6 +369,7 @@ describe("SquareWineSyncService", () => {
       {
         squareVariationId: "square-item-punct-variation",
         variationName: "Square Variation square-item-punct-variation",
+        servingMode: "UNKNOWN",
         price: 0,
         isPublic: true,
         isDefault: false,
@@ -415,6 +421,7 @@ describe("SquareWineSyncService", () => {
       {
         squareVariationId: "var-2oz",
         variationName: "2oz",
+        servingMode: "FLIGHT_2OZ",
         price: 9,
         volumeOz: 2,
         isPublic: false,
@@ -427,6 +434,7 @@ describe("SquareWineSyncService", () => {
       {
         squareVariationId: "var-9oz",
         variationName: "9oz",
+        servingMode: "GLASS_9OZ",
         price: 25,
         volumeOz: 9,
         isPublic: true,
@@ -437,5 +445,85 @@ describe("SquareWineSyncService", () => {
         isFeatured: false
       }
     ]);
+  });
+
+  it("applies serving mode override when configured for square variation id", async () => {
+    const repository = createSquareSyncRepositoryMock();
+    vi.mocked(repository.findServingModeOverrides).mockResolvedValue({
+      "var-override": "BOTTLE_750ML"
+    });
+    const service = new SquareWineSyncService(repository);
+
+    const catalogObjects = [
+      {
+        type: "ITEM",
+        id: "square-item-override",
+        itemData: {
+          name: "Override Test",
+          variations: [
+            {
+              id: "var-override",
+              itemVariationData: {
+                name: "5oz",
+                priceMoney: {
+                  amount: 1500
+                }
+              }
+            }
+          ]
+        }
+      }
+    ] as never[];
+
+    await service.syncCatalogObjects(catalogObjects);
+
+    expect(repository.replaceInventoryForWine).toHaveBeenCalledWith(
+      "wine-created",
+      expect.arrayContaining([
+        expect.objectContaining({
+          squareVariationId: "var-override",
+          servingMode: "BOTTLE_750ML"
+        })
+      ])
+    );
+  });
+
+  it("infers bottle serving mode from variation naming", async () => {
+    const repository = createSquareSyncRepositoryMock();
+    const service = new SquareWineSyncService(repository);
+
+    const catalogObjects = [
+      {
+        type: "ITEM",
+        id: "square-item-bottle",
+        itemData: {
+          name: "Bottle Test",
+          variations: [
+            {
+              id: "var-bottle",
+              itemVariationData: {
+                name: "750ml bottle",
+                priceMoney: {
+                  amount: 4900
+                }
+              }
+            }
+          ]
+        }
+      }
+    ] as never[];
+
+    await service.syncCatalogObjects(catalogObjects);
+
+    expect(repository.replaceInventoryForWine).toHaveBeenCalledWith(
+      "wine-created",
+      expect.arrayContaining([
+        expect.objectContaining({
+          squareVariationId: "var-bottle",
+          servingMode: "BOTTLE_750ML",
+          isPublic: true
+        })
+      ])
+    );
   });
 });

--- a/src/integrations/square/squareWineSyncService.ts
+++ b/src/integrations/square/squareWineSyncService.ts
@@ -63,8 +63,11 @@ export class SquareWineSyncService {
         created += 1;
       }
 
+      const variationIds = item.variations.map((variation) => variation.id);
+      const servingModeOverrides = await this.squareSyncRepository.findServingModeOverrides(variationIds);
+
       const inventoryRows = this.catalogParser
-        .mapVariationsToInventoryRows(item.variations, item.id)
+        .mapVariationsToInventoryRows(item.variations, item.id, servingModeOverrides)
         .map((row) => ({
           ...row,
           locationId: `square:${item.id}`
@@ -87,10 +90,10 @@ export class SquareWineSyncService {
         lastSyncedAt: syncedAt
       });
 
-      const variationIds = inventoryRows
+      const variationIdsInRows = inventoryRows
         .map((row) => row.squareVariationId)
         .filter((value): value is string => Boolean(value));
-      const variationLookup = await this.squareSyncRepository.findWineVariationsBySquareVariationIds(wine.id, variationIds);
+      const variationLookup = await this.squareSyncRepository.findWineVariationsBySquareVariationIds(wine.id, variationIdsInRows);
       const wineVariationIdBySquareVariationId = new Map(
         variationLookup
           .filter((variation) => variation.squareVariationId)

--- a/src/repositories/squareSync/ISquareSyncRepository.ts
+++ b/src/repositories/squareSync/ISquareSyncRepository.ts
@@ -1,8 +1,9 @@
-import type { Prisma, Wine } from "@prisma/client";
+import type { Prisma, ServingMode, Wine } from "@prisma/client";
 
 export type InventorySyncRow = {
   squareVariationId?: string;
   variationName: string;
+  servingMode: ServingMode;
   price: number;
   volumeOz?: number;
   isPublic?: boolean;
@@ -44,6 +45,7 @@ export interface ISquareSyncRepository {
   updateWineSquareFieldsBySquareItemId(squareItemId: string, input: Prisma.WineUncheckedUpdateInput): Promise<Wine>;
   upsertSquareCatalogItem(input: SquareCatalogItemUpsertInput): Promise<{ id: string }>;
   upsertSquareCatalogVariation(input: SquareCatalogVariationUpsertInput): Promise<void>;
+  findServingModeOverrides(squareVariationIds: string[]): Promise<Record<string, ServingMode>>;
   replaceInventoryForWine(wineId: string, rows: InventorySyncRow[]): Promise<number>;
   findWineVariationsBySquareVariationIds(wineId: string, squareVariationIds: string[]): Promise<WineVariationKey[]>;
 }

--- a/src/repositories/squareSync/SquareSyncRepository.ts
+++ b/src/repositories/squareSync/SquareSyncRepository.ts
@@ -107,6 +107,29 @@ export class SquareSyncRepository implements ISquareSyncRepository {
     });
   }
 
+  public async findServingModeOverrides(squareVariationIds: string[]) {
+    if (squareVariationIds.length === 0) {
+      return {};
+    }
+
+    const overrides = await this.prisma.squareServingModeOverride.findMany({
+      where: {
+        squareVariationId: {
+          in: squareVariationIds
+        }
+      },
+      select: {
+        squareVariationId: true,
+        servingMode: true
+      }
+    });
+
+    return overrides.reduce<Record<string, (typeof overrides)[number]["servingMode"]>>((acc, row) => {
+      acc[row.squareVariationId] = row.servingMode;
+      return acc;
+    }, {});
+  }
+
   public async findWineVariationsBySquareVariationIds(wineId: string, squareVariationIds: string[]) {
     if (squareVariationIds.length === 0) {
       return [];
@@ -172,7 +195,13 @@ export class SquareSyncRepository implements ISquareSyncRepository {
               price: row.price,
               volumeOz: row.volumeOz ?? null,
               isPublic: row.isPublic ?? true,
-              isDefault: (row.squareVariationId || row.variationName) === selectedDefaultKey
+              isDefault: (row.squareVariationId || row.variationName) === selectedDefaultKey,
+              servingModeConfig: {
+                create: {
+                  servingMode: row.servingMode,
+                  isAvailable: row.isAvailable
+                }
+              }
             }
           })
         )

--- a/src/repositories/wine/WineRepository.test.ts
+++ b/src/repositories/wine/WineRepository.test.ts
@@ -16,11 +16,15 @@ describe("WineRepository", () => {
 
     expect(findMany).toHaveBeenCalledWith({
       where: {
-        variations: {
-          some: {
-            isPublic: true
+        AND: [
+          {
+            variations: {
+              some: {
+                isPublic: true
+              }
+            }
           }
-        }
+        ]
       },
       include: {
         winery: true,
@@ -68,11 +72,112 @@ describe("WineRepository", () => {
             isFeatured: true
           }
         },
+        AND: [
+          {
+            variations: {
+              some: {
+                isPublic: true
+              }
+            }
+          },
+          {
+            variations: {
+              some: {
+                servingModeConfig: {
+                  is: {
+                    servingMode: {
+                      in: ["GLASS_5OZ", "GLASS_9OZ"]
+                    },
+                    isAvailable: true
+                  }
+                }
+              }
+            }
+          },
+          {
+            variations: {
+              some: {
+                servingModeConfig: {
+                  is: {
+                    servingMode: "BOTTLE_750ML",
+                    isAvailable: true
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      include: {
+        winery: true,
+        region: true,
+        inventory: true,
         variations: {
-          some: {
+          where: {
             isPublic: true
           }
         }
+      },
+      orderBy: { createdAt: "desc" }
+    });
+  });
+
+  it("findMany applies negative hasGlass and hasBottle filters", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const prisma = {
+      wine: {
+        findMany
+      }
+    } as never;
+
+    const repository = new WineRepository(prisma);
+
+    await repository.findMany({
+      hasGlass: false,
+      hasBottle: false
+    });
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        AND: [
+          {
+            variations: {
+              some: {
+                isPublic: true
+              }
+            }
+          },
+          {
+            NOT: {
+              variations: {
+                some: {
+                  servingModeConfig: {
+                    is: {
+                      servingMode: {
+                        in: ["GLASS_5OZ", "GLASS_9OZ"]
+                      },
+                      isAvailable: true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          {
+            NOT: {
+              variations: {
+                some: {
+                  servingModeConfig: {
+                    is: {
+                      servingMode: "BOTTLE_750ML",
+                      isAvailable: true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
       },
       include: {
         winery: true,

--- a/src/repositories/wine/WineRepository.ts
+++ b/src/repositories/wine/WineRepository.ts
@@ -111,6 +111,68 @@ export class WineRepository implements IWineRepository {
     filters: WineListFilters,
     variationWhere: Prisma.WineVariationWhereInput
   ): Prisma.WineWhereInput {
+    const glassVariationPredicate: Prisma.WineVariationWhereInput = {
+      servingModeConfig: {
+        is: {
+          servingMode: { in: ["GLASS_5OZ", "GLASS_9OZ"] },
+          isAvailable: true
+        }
+      }
+    };
+
+    const bottleVariationPredicate: Prisma.WineVariationWhereInput = {
+      servingModeConfig: {
+        is: {
+          servingMode: "BOTTLE_750ML",
+          isAvailable: true
+        }
+      }
+    };
+
+    const andClauses: Prisma.WineWhereInput[] = [
+      {
+        variations: {
+          some: variationWhere
+        }
+      }
+    ];
+
+    if (filters.hasGlass === true) {
+      andClauses.push({
+        variations: {
+          some: glassVariationPredicate
+        }
+      });
+    }
+
+    if (filters.hasGlass === false) {
+      andClauses.push({
+        NOT: {
+          variations: {
+            some: glassVariationPredicate
+          }
+        }
+      });
+    }
+
+    if (filters.hasBottle === true) {
+      andClauses.push({
+        variations: {
+          some: bottleVariationPredicate
+        }
+      });
+    }
+
+    if (filters.hasBottle === false) {
+      andClauses.push({
+        NOT: {
+          variations: {
+            some: bottleVariationPredicate
+          }
+        }
+      });
+    }
+
     return {
       ...(filters.country
         ? {
@@ -123,9 +185,7 @@ export class WineRepository implements IWineRepository {
       ...(filters.regionId ? { regionId: filters.regionId } : {}),
       ...(filters.wineryId ? { wineryId: filters.wineryId } : {}),
       ...(filters.featuredOnly ? { inventory: { some: { isFeatured: true } } } : {}),
-      variations: {
-        some: variationWhere
-      }
+      AND: andClauses
     };
   }
 }


### PR DESCRIPTION
## Issues

Closes #40

## Summary

Models serving modes (bottle, glass, flight, unknown) for wine variations. Adds a `ServingMode` enum and a `WineVariationServingMode` join table so each variation carries an explicit serving mode inferred from Square catalog data. Includes an admin override table (`SquareServingModeOverride`) and updates the wine list filters (`hasGlass`, `hasBottle`) to query based on serving mode predicates rather than raw name matching.

## Changes

- Add `ServingMode` enum (`BOTTLE_750ML`, `GLASS_5OZ`, `GLASS_9OZ`, `FLIGHT_2OZ`, `UNKNOWN`) to Prisma schema
- Add `WineVariationServingMode` model (1-to-1 with `WineVariation`) to persist inferred or overridden mode
- Add `SquareServingModeOverride` model for admin-controlled mode assignments by Square variation ID
- Add `inferServingMode` logic to `SquareCatalogParser` with override-map support
- Update `ISquareSyncRepository` / `SquareSyncRepository` to look up overrides and persist serving mode config on sync
- Update `WineRepository.findMany` `hasGlass`/`hasBottle` filters to use serving mode predicates
- Add Prisma migration `20260323153800_issue40_serving_modes`
- 100% unit test coverage maintained (122 tests)

## Verification

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npx prisma validate`
- [ ] Relevant endpoint checks completed

## Checklist

- [x] No secrets were added
- [ ] README and docs updated (if needed)
- [x] Backward compatibility considered
