### PR TITLE
feat(Issue #41): Model flight composition and wine-flight association

### DIFF
--- a/prisma/migrations/20260323162000_issue41_flight_composition/migration.sql
+++ b/prisma/migrations/20260323162000_issue41_flight_composition/migration.sql
@@ -1,0 +1,40 @@
+-- CreateTable
+CREATE TABLE "public"."Flight" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Flight_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."FlightWine" (
+    "id" TEXT NOT NULL,
+    "flightId" TEXT NOT NULL,
+    "wineId" TEXT NOT NULL,
+    "position" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FlightWine_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Flight_isActive_idx" ON "public"."Flight"("isActive");
+
+-- CreateIndex
+CREATE INDEX "FlightWine_flightId_position_idx" ON "public"."FlightWine"("flightId", "position");
+
+-- CreateIndex
+CREATE INDEX "FlightWine_wineId_idx" ON "public"."FlightWine"("wineId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FlightWine_flightId_wineId_key" ON "public"."FlightWine"("flightId", "wineId");
+
+-- AddForeignKey
+ALTER TABLE "public"."FlightWine" ADD CONSTRAINT "FlightWine_flightId_fkey" FOREIGN KEY ("flightId") REFERENCES "public"."Flight"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."FlightWine" ADD CONSTRAINT "FlightWine_wineId_fkey" FOREIGN KEY ("wineId") REFERENCES "public"."Wine"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,7 @@ model Wine {
   winery    Winery           @relation(fields: [wineryId], references: [id], onDelete: Restrict)
   region    Region           @relation(fields: [regionId], references: [id], onDelete: Restrict)
   variations WineVariation[]
+  flightMemberships FlightWine[]
   ratings   Rating[]
   inventory Inventory[]
   squareCatalogItem SquareCatalogItem?
@@ -40,6 +41,33 @@ model Wine {
   @@unique([name, wineryId, vintage])
   @@index([regionId])
   @@index([wineryId])
+}
+
+model Flight {
+  id          String      @id @default(uuid())
+  name        String
+  description String?
+  isActive    Boolean     @default(true)
+  createdAt   DateTime    @default(now())
+
+  wines       FlightWine[]
+
+  @@index([isActive])
+}
+
+model FlightWine {
+  id        String   @id @default(uuid())
+  flightId  String
+  wineId    String
+  position  Int      @default(0)
+  createdAt DateTime @default(now())
+
+  flight    Flight   @relation(fields: [flightId], references: [id], onDelete: Cascade)
+  wine      Wine     @relation(fields: [wineId], references: [id], onDelete: Cascade)
+
+  @@unique([flightId, wineId])
+  @@index([flightId, position])
+  @@index([wineId])
 }
 
 model WineVariation {

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,8 +1,10 @@
 import { prisma } from "@/config/prisma";
 import { AuthController } from "@/controllers/authController";
+import { FlightController } from "@/controllers/flightController";
 import { InventoryController } from "@/controllers/inventoryController";
 import { RatingController } from "@/controllers/ratingController";
 import { WineController } from "@/controllers/wineController";
+import { FlightRepository } from "@/repositories/flight/FlightRepository";
 import { InventoryRepository } from "@/repositories/inventory/InventoryRepository";
 import { RatingRepository } from "@/repositories/rating/RatingRepository";
 import { RegionRepository } from "@/repositories/region/RegionRepository";
@@ -10,6 +12,7 @@ import { UserRepository } from "@/repositories/user/UserRepository";
 import { WineRepository } from "@/repositories/wine/WineRepository";
 import { WineryRepository } from "@/repositories/winery/WineryRepository";
 import { AuthService } from "@/services/authService";
+import { FlightService } from "@/services/flightService";
 import { InventoryService } from "@/services/inventoryService";
 import { RatingService } from "@/services/ratingService";
 import { WineService } from "@/services/wineService";
@@ -19,6 +22,7 @@ const wineryRepository = new WineryRepository(prisma);
 const regionRepository = new RegionRepository(prisma);
 const ratingRepository = new RatingRepository(prisma);
 const inventoryRepository = new InventoryRepository(prisma);
+const flightRepository = new FlightRepository(prisma);
 const userRepository = new UserRepository(prisma);
 
 const wineService = new WineService(
@@ -29,9 +33,11 @@ const wineService = new WineService(
 );
 const inventoryService = new InventoryService(inventoryRepository);
 const ratingService = new RatingService(ratingRepository, wineRepository);
+const flightService = new FlightService(flightRepository, wineRepository);
 const authService = new AuthService(userRepository);
 
 export const authController = new AuthController(authService);
 export const wineController = new WineController(wineService);
 export const inventoryController = new InventoryController(inventoryService);
 export const ratingController = new RatingController(ratingService);
+export const flightController = new FlightController(flightService);

--- a/src/controllers/flightController.test.ts
+++ b/src/controllers/flightController.test.ts
@@ -1,0 +1,223 @@
+import type { Request, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+import { FlightController } from "@/controllers/flightController";
+import type { FlightService } from "@/services/flightService";
+
+function createResponse() {
+  const res = {
+    status: vi.fn(),
+    json: vi.fn(),
+    send: vi.fn()
+  } as unknown as Response;
+
+  vi.mocked(res.status).mockReturnValue(res);
+  vi.mocked(res.json).mockReturnValue(res);
+  vi.mocked(res.send).mockReturnValue(res);
+
+  return res;
+}
+
+describe("FlightController", () => {
+  it("listFlights returns 200", async () => {
+    const flightService = {
+      getFlights: vi.fn(),
+      getFlightById: vi.fn(),
+      createFlight: vi.fn(),
+      updateFlight: vi.fn(),
+      deleteFlight: vi.fn(),
+      getFlightWines: vi.fn(),
+      addWineToFlight: vi.fn(),
+      removeWineFromFlight: vi.fn(),
+      isWineFeaturedInFlight: vi.fn()
+    } as unknown as FlightService;
+
+    vi.mocked(flightService.getFlights).mockResolvedValue([{ id: "f1" }] as never);
+
+    const controller = new FlightController(flightService);
+    const req = { query: { activeOnly: "true" } } as unknown as Request;
+    const res = createResponse();
+
+    await controller.listFlights(req, res);
+
+    expect(flightService.getFlights).toHaveBeenCalledWith(true);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith([{ id: "f1" }]);
+  });
+
+  it("getFlight returns 200", async () => {
+    const flightService = {
+      getFlights: vi.fn(),
+      getFlightById: vi.fn(),
+      createFlight: vi.fn(),
+      updateFlight: vi.fn(),
+      deleteFlight: vi.fn(),
+      getFlightWines: vi.fn(),
+      addWineToFlight: vi.fn(),
+      removeWineFromFlight: vi.fn(),
+      isWineFeaturedInFlight: vi.fn()
+    } as unknown as FlightService;
+
+    vi.mocked(flightService.getFlightById).mockResolvedValue({ id: "f1" } as never);
+
+    const controller = new FlightController(flightService);
+    const req = { params: { id: "f1" } } as unknown as Request;
+    const res = createResponse();
+
+    await controller.getFlight(req, res);
+
+    expect(flightService.getFlightById).toHaveBeenCalledWith("f1");
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("addFlight returns 201", async () => {
+    const flightService = {
+      getFlights: vi.fn(),
+      getFlightById: vi.fn(),
+      createFlight: vi.fn(),
+      updateFlight: vi.fn(),
+      deleteFlight: vi.fn(),
+      getFlightWines: vi.fn(),
+      addWineToFlight: vi.fn(),
+      removeWineFromFlight: vi.fn(),
+      isWineFeaturedInFlight: vi.fn()
+    } as unknown as FlightService;
+
+    vi.mocked(flightService.createFlight).mockResolvedValue({ id: "f1" } as never);
+
+    const controller = new FlightController(flightService);
+    const req = { body: { name: "Weekend" } } as Request;
+    const res = createResponse();
+
+    await controller.addFlight(req, res);
+
+    expect(flightService.createFlight).toHaveBeenCalledWith(req.body);
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("patchFlight returns 200", async () => {
+    const flightService = {
+      getFlights: vi.fn(),
+      getFlightById: vi.fn(),
+      createFlight: vi.fn(),
+      updateFlight: vi.fn(),
+      deleteFlight: vi.fn(),
+      getFlightWines: vi.fn(),
+      addWineToFlight: vi.fn(),
+      removeWineFromFlight: vi.fn(),
+      isWineFeaturedInFlight: vi.fn()
+    } as unknown as FlightService;
+
+    vi.mocked(flightService.updateFlight).mockResolvedValue({ id: "f1", isActive: false } as never);
+
+    const controller = new FlightController(flightService);
+    const req = { params: { id: "f1" }, body: { isActive: false } } as unknown as Request;
+    const res = createResponse();
+
+    await controller.patchFlight(req, res);
+
+    expect(flightService.updateFlight).toHaveBeenCalledWith("f1", { isActive: false });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("deleteFlight returns 204", async () => {
+    const flightService = {
+      getFlights: vi.fn(),
+      getFlightById: vi.fn(),
+      createFlight: vi.fn(),
+      updateFlight: vi.fn(),
+      deleteFlight: vi.fn(),
+      getFlightWines: vi.fn(),
+      addWineToFlight: vi.fn(),
+      removeWineFromFlight: vi.fn(),
+      isWineFeaturedInFlight: vi.fn()
+    } as unknown as FlightService;
+
+    vi.mocked(flightService.deleteFlight).mockResolvedValue(undefined);
+
+    const controller = new FlightController(flightService);
+    const req = { params: { id: "f1" } } as unknown as Request;
+    const res = createResponse();
+
+    await controller.deleteFlight(req, res);
+
+    expect(flightService.deleteFlight).toHaveBeenCalledWith("f1");
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  it("listFlightWines returns 200", async () => {
+    const flightService = {
+      getFlights: vi.fn(),
+      getFlightById: vi.fn(),
+      createFlight: vi.fn(),
+      updateFlight: vi.fn(),
+      deleteFlight: vi.fn(),
+      getFlightWines: vi.fn(),
+      addWineToFlight: vi.fn(),
+      removeWineFromFlight: vi.fn(),
+      isWineFeaturedInFlight: vi.fn()
+    } as unknown as FlightService;
+
+    vi.mocked(flightService.getFlightWines).mockResolvedValue([{ id: "w1" }] as never);
+
+    const controller = new FlightController(flightService);
+    const req = { params: { id: "f1" } } as unknown as Request;
+    const res = createResponse();
+
+    await controller.listFlightWines(req, res);
+
+    expect(flightService.getFlightWines).toHaveBeenCalledWith("f1");
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("addWineToFlight returns 201", async () => {
+    const flightService = {
+      getFlights: vi.fn(),
+      getFlightById: vi.fn(),
+      createFlight: vi.fn(),
+      updateFlight: vi.fn(),
+      deleteFlight: vi.fn(),
+      getFlightWines: vi.fn(),
+      addWineToFlight: vi.fn(),
+      removeWineFromFlight: vi.fn(),
+      isWineFeaturedInFlight: vi.fn()
+    } as unknown as FlightService;
+
+    vi.mocked(flightService.addWineToFlight).mockResolvedValue({ id: "row-1" } as never);
+
+    const controller = new FlightController(flightService);
+    const req = { params: { id: "f1" }, body: { wineId: "w1" } } as unknown as Request;
+    const res = createResponse();
+
+    await controller.addWineToFlight(req, res);
+
+    expect(flightService.addWineToFlight).toHaveBeenCalledWith("f1", { wineId: "w1" });
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("removeWineFromFlight returns 204", async () => {
+    const flightService = {
+      getFlights: vi.fn(),
+      getFlightById: vi.fn(),
+      createFlight: vi.fn(),
+      updateFlight: vi.fn(),
+      deleteFlight: vi.fn(),
+      getFlightWines: vi.fn(),
+      addWineToFlight: vi.fn(),
+      removeWineFromFlight: vi.fn(),
+      isWineFeaturedInFlight: vi.fn()
+    } as unknown as FlightService;
+
+    vi.mocked(flightService.removeWineFromFlight).mockResolvedValue(undefined);
+
+    const controller = new FlightController(flightService);
+    const req = { params: { id: "f1", wineId: "w1" } } as unknown as Request;
+    const res = createResponse();
+
+    await controller.removeWineFromFlight(req, res);
+
+    expect(flightService.removeWineFromFlight).toHaveBeenCalledWith("f1", "w1");
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.send).toHaveBeenCalled();
+  });
+});

--- a/src/controllers/flightController.ts
+++ b/src/controllers/flightController.ts
@@ -1,0 +1,55 @@
+import type { Request, Response } from "express";
+import { listFlightsQuerySchema } from "@/models/validation";
+import { FlightService } from "@/services/flightService";
+
+export class FlightController {
+  public constructor(private readonly flightService: FlightService) { }
+
+  public listFlights = async (req: Request, res: Response) => {
+    const query = listFlightsQuerySchema.parse(req.query);
+    const flights = await this.flightService.getFlights(query.activeOnly);
+    res.status(200).json(flights);
+  };
+
+  public getFlight = async (req: Request, res: Response) => {
+    const flightId = req.params.id as string;
+    const flight = await this.flightService.getFlightById(flightId);
+    res.status(200).json(flight);
+  };
+
+  public addFlight = async (req: Request, res: Response) => {
+    const flight = await this.flightService.createFlight(req.body);
+    res.status(201).json(flight);
+  };
+
+  public patchFlight = async (req: Request, res: Response) => {
+    const flightId = req.params.id as string;
+    const flight = await this.flightService.updateFlight(flightId, req.body);
+    res.status(200).json(flight);
+  };
+
+  public deleteFlight = async (req: Request, res: Response) => {
+    const flightId = req.params.id as string;
+    await this.flightService.deleteFlight(flightId);
+    res.status(204).send();
+  };
+
+  public listFlightWines = async (req: Request, res: Response) => {
+    const flightId = req.params.id as string;
+    const wines = await this.flightService.getFlightWines(flightId);
+    res.status(200).json(wines);
+  };
+
+  public addWineToFlight = async (req: Request, res: Response) => {
+    const flightId = req.params.id as string;
+    const membership = await this.flightService.addWineToFlight(flightId, req.body);
+    res.status(201).json(membership);
+  };
+
+  public removeWineFromFlight = async (req: Request, res: Response) => {
+    const flightId = req.params.id as string;
+    const wineId = req.params.wineId as string;
+    await this.flightService.removeWineFromFlight(flightId, wineId);
+    res.status(204).send();
+  };
+}

--- a/src/models/validation.test.ts
+++ b/src/models/validation.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { createInventorySchema, createWineSchema, listWinesSchema, updateInventorySchema } from "@/models/validation";
+import {
+  addWineToFlightSchema,
+  createFlightSchema,
+  createInventorySchema,
+  createWineSchema,
+  listFlightsQuerySchema,
+  listWinesSchema,
+  updateFlightSchema,
+  updateInventorySchema
+} from "@/models/validation";
 
 describe("listWinesSchema", () => {
   it("applies defaults and transforms string booleans", () => {
@@ -108,6 +117,50 @@ describe("inventory schemas", () => {
     ).toEqual({
       sealedBottleCount: 4,
       isAvailable: true
+    });
+  });
+});
+
+describe("flight schemas", () => {
+  it("parses list flights query with boolean string", () => {
+    expect(listFlightsQuerySchema.parse({ activeOnly: "false" })).toEqual({
+      activeOnly: false
+    });
+  });
+
+  it("accepts create flight payload", () => {
+    expect(
+      createFlightSchema.parse({
+        name: "Weekend Flight",
+        description: "Three pours",
+        isActive: true
+      })
+    ).toEqual({
+      name: "Weekend Flight",
+      description: "Three pours",
+      isActive: true
+    });
+  });
+
+  it("accepts update flight payload", () => {
+    expect(
+      updateFlightSchema.parse({
+        isActive: false
+      })
+    ).toEqual({
+      isActive: false
+    });
+  });
+
+  it("accepts add wine to flight payload", () => {
+    expect(
+      addWineToFlightSchema.parse({
+        wineId: "11111111-1111-4111-8111-111111111111",
+        position: 1
+      })
+    ).toEqual({
+      wineId: "11111111-1111-4111-8111-111111111111",
+      position: 1
     });
   });
 });

--- a/src/models/validation.ts
+++ b/src/models/validation.ts
@@ -53,6 +53,27 @@ export const listWinesSchema = wineListFilterSchema.extend({
 
 export const groupedWinesSchema = wineListFilterSchema;
 
+export const listFlightsQuerySchema = z.object({
+  activeOnly: booleanQuerySchema.optional()
+});
+
+export const createFlightSchema = z.object({
+  name: z.string().trim().min(1),
+  description: z.string().trim().min(1).optional(),
+  isActive: z.boolean().optional()
+});
+
+export const updateFlightSchema = z.object({
+  name: z.string().trim().min(1).optional(),
+  description: z.string().trim().min(1).optional(),
+  isActive: z.boolean().optional()
+});
+
+export const addWineToFlightSchema = z.object({
+  wineId: z.string().uuid(),
+  position: z.number().int().min(0).optional()
+});
+
 export const createInventorySchema = z.object({
   wineId: z.string().uuid(),
   locationId: z.string().min(1),

--- a/src/repositories/flight/FlightRepository.test.ts
+++ b/src/repositories/flight/FlightRepository.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from "vitest";
+import { FlightRepository } from "@/repositories/flight/FlightRepository";
+
+describe("FlightRepository", () => {
+  it("findMany filters by active state when activeOnly is true", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const prisma = {
+      flight: {
+        findMany
+      }
+    } as never;
+
+    const repository = new FlightRepository(prisma);
+
+    await repository.findMany(true);
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: { isActive: true },
+      orderBy: { createdAt: "desc" }
+    });
+  });
+
+  it("findMany returns all flights when activeOnly is undefined", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const prisma = {
+      flight: {
+        findMany
+      }
+    } as never;
+
+    const repository = new FlightRepository(prisma);
+
+    await repository.findMany();
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: undefined,
+      orderBy: { createdAt: "desc" }
+    });
+  });
+
+  it("findById reads flight by id", async () => {
+    const findUnique = vi.fn().mockResolvedValue(null);
+    const prisma = {
+      flight: {
+        findUnique
+      }
+    } as never;
+
+    const repository = new FlightRepository(prisma);
+
+    await repository.findById("flight-1");
+
+    expect(findUnique).toHaveBeenCalledWith({ where: { id: "flight-1" } });
+  });
+
+  it("create writes a flight record", async () => {
+    const create = vi.fn().mockResolvedValue(null);
+    const prisma = {
+      flight: {
+        create
+      }
+    } as never;
+
+    const repository = new FlightRepository(prisma);
+    const input = { name: "Tasting Flight", isActive: true };
+
+    await repository.create(input);
+
+    expect(create).toHaveBeenCalledWith({ data: input });
+  });
+
+  it("update writes partial fields", async () => {
+    const update = vi.fn().mockResolvedValue(null);
+    const prisma = {
+      flight: {
+        update
+      }
+    } as never;
+
+    const repository = new FlightRepository(prisma);
+
+    await repository.update("flight-1", { isActive: false });
+
+    expect(update).toHaveBeenCalledWith({
+      where: { id: "flight-1" },
+      data: { isActive: false }
+    });
+  });
+
+  it("delete removes a flight by id", async () => {
+    const del = vi.fn().mockResolvedValue(null);
+    const prisma = {
+      flight: {
+        delete: del
+      }
+    } as never;
+
+    const repository = new FlightRepository(prisma);
+
+    await repository.delete("flight-1");
+
+    expect(del).toHaveBeenCalledWith({
+      where: { id: "flight-1" }
+    });
+  });
+
+  it("addWineToFlight creates membership row", async () => {
+    const create = vi.fn().mockResolvedValue(null);
+    const prisma = {
+      flightWine: {
+        create
+      }
+    } as never;
+
+    const repository = new FlightRepository(prisma);
+
+    await repository.addWineToFlight("flight-1", "wine-1", 2);
+
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        flight: { connect: { id: "flight-1" } },
+        wine: { connect: { id: "wine-1" } },
+        position: 2
+      }
+    });
+  });
+
+  it("removeWineFromFlight deletes membership and returns count", async () => {
+    const deleteMany = vi.fn().mockResolvedValue({ count: 1 });
+    const prisma = {
+      flightWine: {
+        deleteMany
+      }
+    } as never;
+
+    const repository = new FlightRepository(prisma);
+
+    await expect(repository.removeWineFromFlight("flight-1", "wine-1")).resolves.toBe(1);
+    expect(deleteMany).toHaveBeenCalledWith({
+      where: {
+        flightId: "flight-1",
+        wineId: "wine-1"
+      }
+    });
+  });
+
+  it("findWinesByFlight returns ordered wine records", async () => {
+    const findMany = vi.fn().mockResolvedValue([
+      { wine: { id: "wine-1", name: "A" } },
+      { wine: { id: "wine-2", name: "B" } }
+    ]);
+    const prisma = {
+      flightWine: {
+        findMany
+      }
+    } as never;
+
+    const repository = new FlightRepository(prisma);
+
+    await expect(repository.findWinesByFlight("flight-1")).resolves.toEqual([
+      { id: "wine-1", name: "A" },
+      { id: "wine-2", name: "B" }
+    ]);
+    expect(findMany).toHaveBeenCalledWith({
+      where: { flightId: "flight-1" },
+      include: {
+        wine: true
+      },
+      orderBy: {
+        position: "asc"
+      }
+    });
+  });
+
+  it("isWineInActiveFlight returns true when count is positive", async () => {
+    const count = vi.fn().mockResolvedValue(2);
+    const prisma = {
+      flightWine: {
+        count
+      }
+    } as never;
+
+    const repository = new FlightRepository(prisma);
+
+    await expect(repository.isWineInActiveFlight("wine-1")).resolves.toBe(true);
+    expect(count).toHaveBeenCalledWith({
+      where: {
+        wineId: "wine-1",
+        flight: {
+          isActive: true
+        }
+      }
+    });
+  });
+
+  it("isWineInActiveFlight returns false when count is zero", async () => {
+    const count = vi.fn().mockResolvedValue(0);
+    const prisma = {
+      flightWine: {
+        count
+      }
+    } as never;
+
+    const repository = new FlightRepository(prisma);
+
+    await expect(repository.isWineInActiveFlight("wine-1")).resolves.toBe(false);
+  });
+});

--- a/src/repositories/flight/FlightRepository.ts
+++ b/src/repositories/flight/FlightRepository.ts
@@ -1,0 +1,86 @@
+import type { Prisma, PrismaClient } from "@prisma/client";
+import type { IFlightRepository } from "@/repositories/flight/IFlightRepository";
+
+export class FlightRepository implements IFlightRepository {
+  public constructor(private readonly prisma: PrismaClient) { }
+
+  public async findMany(activeOnly?: boolean) {
+    return this.prisma.flight.findMany({
+      ...(activeOnly === true ? { where: { isActive: true } } : {}),
+      orderBy: { createdAt: "desc" }
+    });
+  }
+
+  public async findById(id: string) {
+    return this.prisma.flight.findUnique({
+      where: { id }
+    });
+  }
+
+  public async create(input: Prisma.FlightCreateInput) {
+    return this.prisma.flight.create({
+      data: input
+    });
+  }
+
+  public async update(id: string, input: Prisma.FlightUpdateInput) {
+    return this.prisma.flight.update({
+      where: { id },
+      data: input
+    });
+  }
+
+  public async delete(id: string) {
+    await this.prisma.flight.delete({
+      where: { id }
+    });
+  }
+
+  public async addWineToFlight(flightId: string, wineId: string, position: number) {
+    return this.prisma.flightWine.create({
+      data: {
+        flight: { connect: { id: flightId } },
+        wine: { connect: { id: wineId } },
+        position
+      }
+    });
+  }
+
+  public async removeWineFromFlight(flightId: string, wineId: string) {
+    const deleted = await this.prisma.flightWine.deleteMany({
+      where: {
+        flightId,
+        wineId
+      }
+    });
+
+    return deleted.count;
+  }
+
+  public async findWinesByFlight(flightId: string) {
+    const rows = await this.prisma.flightWine.findMany({
+      where: { flightId },
+      include: {
+        wine: true
+      },
+      orderBy: {
+        position: "asc"
+      }
+    });
+
+    return rows.map((row) => row.wine);
+  }
+
+  public async isWineInActiveFlight(wineId: string) {
+    const membershipCount = await this.prisma.flightWine.count({
+      where: {
+        wineId,
+        flight: {
+          isActive: true
+        }
+      }
+    });
+
+    return membershipCount > 0;
+  }
+}

--- a/src/repositories/flight/IFlightRepository.ts
+++ b/src/repositories/flight/IFlightRepository.ts
@@ -1,0 +1,17 @@
+import type { Flight, FlightWine, Prisma, Wine } from "@prisma/client";
+
+export type FlightWithWines = Flight & {
+  wines: (FlightWine & { wine: Wine })[];
+};
+
+export interface IFlightRepository {
+  findMany(activeOnly?: boolean): Promise<Flight[]>;
+  findById(id: string): Promise<Flight | null>;
+  create(input: Prisma.FlightCreateInput): Promise<Flight>;
+  update(id: string, input: Prisma.FlightUpdateInput): Promise<Flight>;
+  delete(id: string): Promise<void>;
+  addWineToFlight(flightId: string, wineId: string, position: number): Promise<FlightWine>;
+  removeWineFromFlight(flightId: string, wineId: string): Promise<number>;
+  findWinesByFlight(flightId: string): Promise<Wine[]>;
+  isWineInActiveFlight(wineId: string): Promise<boolean>;
+}

--- a/src/routes/flightRoutes.ts
+++ b/src/routes/flightRoutes.ts
@@ -1,0 +1,22 @@
+import { Router } from "express";
+import { flightController } from "@/container";
+import { validateRequest } from "@/middleware/validateRequest";
+import { addWineToFlightSchema, createFlightSchema, updateFlightSchema } from "@/models/validation";
+import { asyncHandler } from "@/utils/asyncHandler";
+
+const router = Router();
+
+router.get("/", asyncHandler(flightController.listFlights));
+router.get("/:id", asyncHandler(flightController.getFlight));
+router.post("/", validateRequest(createFlightSchema), asyncHandler(flightController.addFlight));
+router.patch("/:id", validateRequest(updateFlightSchema), asyncHandler(flightController.patchFlight));
+router.delete("/:id", asyncHandler(flightController.deleteFlight));
+router.get("/:id/wines", asyncHandler(flightController.listFlightWines));
+router.post(
+  "/:id/wines",
+  validateRequest(addWineToFlightSchema),
+  asyncHandler(flightController.addWineToFlight)
+);
+router.delete("/:id/wines/:wineId", asyncHandler(flightController.removeWineFromFlight));
+
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import authRoutes from "./authRoutes";
+import flightRoutes from "./flightRoutes";
 import inventoryRoutes from "./inventoryRoutes";
 import ratingRoutes from "./ratingRoutes";
 import wineRoutes from "./wineRoutes";
@@ -14,5 +15,6 @@ router.use("/auth", authRoutes);
 router.use("/wines", wineRoutes);
 router.use("/inventory", inventoryRoutes);
 router.use("/ratings", ratingRoutes);
+router.use("/flights", flightRoutes);
 
 export default router;

--- a/src/services/flightService.test.ts
+++ b/src/services/flightService.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+import type { IFlightRepository } from "@/repositories/flight/IFlightRepository";
+import type { IWineRepository } from "@/repositories/wine/IWineRepository";
+import { FlightService } from "@/services/flightService";
+import { AppError } from "@/utils/appError";
+
+function createService() {
+  const flightRepository: IFlightRepository = {
+    findMany: vi.fn(),
+    findById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    addWineToFlight: vi.fn(),
+    removeWineFromFlight: vi.fn(),
+    findWinesByFlight: vi.fn(),
+    isWineInActiveFlight: vi.fn()
+  };
+
+  const wineRepository: IWineRepository = {
+    findMany: vi.fn(),
+    findByIdWithInventory: vi.fn(),
+    findBySlugWithInventory: vi.fn(),
+    create: vi.fn(),
+    findByUniqueNameWineryVintage: vi.fn(),
+    search: vi.fn(),
+    findBySlug: vi.fn(),
+    findBySquareItemId: vi.fn()
+  };
+
+  return {
+    service: new FlightService(flightRepository, wineRepository),
+    flightRepository,
+    wineRepository
+  };
+}
+
+describe("FlightService", () => {
+  it("returns all flights", async () => {
+    const { service, flightRepository } = createService();
+    const flights = [{ id: "flight-1" }];
+
+    vi.mocked(flightRepository.findMany).mockResolvedValue(flights as never);
+
+    await expect(service.getFlights()).resolves.toEqual(flights);
+  });
+
+  it("returns active flights when requested", async () => {
+    const { service, flightRepository } = createService();
+
+    vi.mocked(flightRepository.findMany).mockResolvedValue([] as never);
+
+    await service.getFlights(true);
+
+    expect(flightRepository.findMany).toHaveBeenCalledWith(true);
+  });
+
+  it("returns flight by id", async () => {
+    const { service, flightRepository } = createService();
+    const flight = { id: "flight-1" };
+
+    vi.mocked(flightRepository.findById).mockResolvedValue(flight as never);
+
+    await expect(service.getFlightById("flight-1")).resolves.toEqual(flight);
+  });
+
+  it("throws when flight is missing", async () => {
+    const { service, flightRepository } = createService();
+
+    vi.mocked(flightRepository.findById).mockResolvedValue(null);
+
+    await expect(service.getFlightById("missing")).rejects.toEqual(new AppError("Flight not found", 404));
+  });
+
+  it("creates flight with default active flag", async () => {
+    const { service, flightRepository } = createService();
+
+    vi.mocked(flightRepository.create).mockResolvedValue({ id: "flight-1" } as never);
+
+    await service.createFlight({ name: "Sunday Flight" });
+
+    expect(flightRepository.create).toHaveBeenCalledWith({
+      name: "Sunday Flight",
+      description: null,
+      isActive: true
+    });
+  });
+
+  it("updates flight after existence check", async () => {
+    const { service, flightRepository } = createService();
+
+    vi.mocked(flightRepository.findById).mockResolvedValue({ id: "flight-1" } as never);
+    vi.mocked(flightRepository.update).mockResolvedValue({ id: "flight-1", isActive: false } as never);
+
+    await service.updateFlight("flight-1", { isActive: false });
+
+    expect(flightRepository.update).toHaveBeenCalledWith("flight-1", { isActive: false });
+  });
+
+  it("deletes flight after existence check", async () => {
+    const { service, flightRepository } = createService();
+
+    vi.mocked(flightRepository.findById).mockResolvedValue({ id: "flight-1" } as never);
+    vi.mocked(flightRepository.delete).mockResolvedValue(undefined);
+
+    await service.deleteFlight("flight-1");
+
+    expect(flightRepository.delete).toHaveBeenCalledWith("flight-1");
+  });
+
+  it("adds wine to flight with default position", async () => {
+    const { service, flightRepository, wineRepository } = createService();
+
+    vi.mocked(flightRepository.findById).mockResolvedValue({ id: "flight-1" } as never);
+    vi.mocked(wineRepository.findByIdWithInventory).mockResolvedValue({ id: "wine-1" } as never);
+    vi.mocked(flightRepository.addWineToFlight).mockResolvedValue({ id: "row-1" } as never);
+
+    await service.addWineToFlight("flight-1", { wineId: "wine-1" });
+
+    expect(flightRepository.addWineToFlight).toHaveBeenCalledWith("flight-1", "wine-1", 0);
+  });
+
+  it("throws when adding missing wine", async () => {
+    const { service, flightRepository, wineRepository } = createService();
+
+    vi.mocked(flightRepository.findById).mockResolvedValue({ id: "flight-1" } as never);
+    vi.mocked(wineRepository.findByIdWithInventory).mockResolvedValue(null);
+
+    await expect(service.addWineToFlight("flight-1", { wineId: "wine-missing" })).rejects.toEqual(
+      new AppError("Wine not found", 404)
+    );
+  });
+
+  it("removes wine from flight", async () => {
+    const { service, flightRepository } = createService();
+
+    vi.mocked(flightRepository.findById).mockResolvedValue({ id: "flight-1" } as never);
+    vi.mocked(flightRepository.removeWineFromFlight).mockResolvedValue(1);
+
+    await service.removeWineFromFlight("flight-1", "wine-1");
+
+    expect(flightRepository.removeWineFromFlight).toHaveBeenCalledWith("flight-1", "wine-1");
+  });
+
+  it("throws when flight membership is missing", async () => {
+    const { service, flightRepository } = createService();
+
+    vi.mocked(flightRepository.findById).mockResolvedValue({ id: "flight-1" } as never);
+    vi.mocked(flightRepository.removeWineFromFlight).mockResolvedValue(0);
+
+    await expect(service.removeWineFromFlight("flight-1", "wine-1")).rejects.toEqual(
+      new AppError("Flight membership not found", 404)
+    );
+  });
+
+  it("returns wines for a flight", async () => {
+    const { service, flightRepository } = createService();
+
+    vi.mocked(flightRepository.findById).mockResolvedValue({ id: "flight-1" } as never);
+    vi.mocked(flightRepository.findWinesByFlight).mockResolvedValue([{ id: "wine-1" }] as never);
+
+    await expect(service.getFlightWines("flight-1")).resolves.toEqual([{ id: "wine-1" }]);
+  });
+
+  it("checks featured-in-flight indicator", async () => {
+    const { service, flightRepository } = createService();
+
+    vi.mocked(flightRepository.isWineInActiveFlight).mockResolvedValue(true);
+
+    await expect(service.isWineFeaturedInFlight("wine-1")).resolves.toBe(true);
+  });
+});

--- a/src/services/flightService.ts
+++ b/src/services/flightService.ts
@@ -1,0 +1,91 @@
+import type { IFlightRepository } from "@/repositories/flight/IFlightRepository";
+import type { IWineRepository } from "@/repositories/wine/IWineRepository";
+import { AppError } from "@/utils/appError";
+
+export type CreateFlightInput = {
+  name: string;
+  description?: string;
+  isActive?: boolean;
+};
+
+export type UpdateFlightInput = {
+  name?: string;
+  description?: string;
+  isActive?: boolean;
+};
+
+export type AddWineToFlightInput = {
+  wineId: string;
+  position?: number;
+};
+
+export class FlightService {
+  public constructor(
+    private readonly flightRepository: IFlightRepository,
+    private readonly wineRepository: IWineRepository
+  ) { }
+
+  public async getFlights(activeOnly?: boolean) {
+    return this.flightRepository.findMany(activeOnly);
+  }
+
+  public async getFlightById(id: string) {
+    const flight = await this.flightRepository.findById(id);
+
+    if (!flight) {
+      throw new AppError("Flight not found", 404);
+    }
+
+    return flight;
+  }
+
+  public async createFlight(input: CreateFlightInput) {
+    return this.flightRepository.create({
+      name: input.name,
+      description: input.description ?? null,
+      isActive: input.isActive ?? true
+    });
+  }
+
+  public async updateFlight(id: string, input: UpdateFlightInput) {
+    await this.getFlightById(id);
+
+    return this.flightRepository.update(id, input);
+  }
+
+  public async deleteFlight(id: string) {
+    await this.getFlightById(id);
+    await this.flightRepository.delete(id);
+  }
+
+  public async addWineToFlight(flightId: string, input: AddWineToFlightInput) {
+    await this.getFlightById(flightId);
+
+    const wine = await this.wineRepository.findByIdWithInventory(input.wineId);
+
+    if (!wine) {
+      throw new AppError("Wine not found", 404);
+    }
+
+    return this.flightRepository.addWineToFlight(flightId, input.wineId, input.position ?? 0);
+  }
+
+  public async removeWineFromFlight(flightId: string, wineId: string) {
+    await this.getFlightById(flightId);
+
+    const deletedCount = await this.flightRepository.removeWineFromFlight(flightId, wineId);
+
+    if (deletedCount === 0) {
+      throw new AppError("Flight membership not found", 404);
+    }
+  }
+
+  public async getFlightWines(flightId: string) {
+    await this.getFlightById(flightId);
+    return this.flightRepository.findWinesByFlight(flightId);
+  }
+
+  public async isWineFeaturedInFlight(wineId: string) {
+    return this.flightRepository.isWineInActiveFlight(wineId);
+  }
+}


### PR DESCRIPTION
## Issues

Closes #41

## Summary

Adds first-class flight composition support so wines can be associated with flights and queried for active flight membership. This introduces dedicated flight models, repository/service/controller layers, route wiring, and validation with full unit test coverage.

## Changes

- Add Prisma models for `Flight` and `FlightWine`, plus wine-to-flight relation updates
- Add flight repository abstraction and implementation:
  - CRUD for flights
  - Add/remove wine membership
  - Ordered wine lookup per flight
  - Active-flight membership indicator by wine
- Add `FlightService` with existence checks and domain errors for missing flights/wines/memberships
- Add `FlightController` endpoints for:
  - list/get/create/update/delete flights
  - list wines in a flight
  - add/remove wines from a flight
- Add `flightRoutes` and mount under `/api/flights`
- Add validation schemas:
  - `listFlightsQuerySchema`
  - `createFlightSchema`
  - `updateFlightSchema`
  - `addWineToFlightSchema`
- Add comprehensive unit tests for repository, service, controller, and validation
- Add and apply migration: `20260323162000_issue41_flight_composition`

## Verification

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npx prisma validate`
- [ ] Relevant endpoint checks completed

## Checklist

- [x] No secrets were added
- [ ] README and docs updated (if needed)
- [x] Backward compatibility considered
