### PR TITLE
feat(Issue #42): Add public wine availability flags and hide pricing details

### DIFF
--- a/src/controllers/wineController.test.ts
+++ b/src/controllers/wineController.test.ts
@@ -94,11 +94,9 @@ describe("WineController", () => {
             id: "region-1",
             name: "Napa Valley"
           },
-          pricing: {
-            glass: 16,
-            bottle: 68
-          },
-          defaultVariation: null
+          availableByBottle: true,
+          availableByGlass: true,
+          availableForFlight: false
         }
       ],
       page: 2,
@@ -132,11 +130,9 @@ describe("WineController", () => {
             id: "region-1",
             name: "Napa Valley"
           },
-          pricing: {
-            glass: 16,
-            bottle: 68
-          },
-          defaultVariation: null
+          availableByBottle: true,
+          availableByGlass: true,
+          availableForFlight: false
         }
       ],
       page: 2,
@@ -157,7 +153,28 @@ describe("WineController", () => {
       getWineRatings: vi.fn()
     } as unknown as WineService;
 
-    vi.mocked(wineService.getWineBySlug).mockResolvedValue(createWineWithInventory());
+    vi.mocked(wineService.getWineBySlug).mockResolvedValue({
+      id: "w1",
+      slug: "cabernet-2020",
+      name: "Cabernet",
+      vintage: 2020,
+      country: "US",
+      description: "Bold",
+      imageUrl: "https://example.com/wine.png",
+      winery: {
+        id: "winery-1",
+        name: "Alpha Winery"
+      },
+      region: {
+        id: "region-1",
+        name: "Napa Valley"
+      },
+      availableByBottle: true,
+      availableByGlass: true,
+      availableForFlight: false,
+      grapeVarieties: ["Cabernet Sauvignon"],
+      alcoholPercent: 13.5
+    });
 
     const controller = new WineController(wineService);
     const req = { params: { slug: "cabernet-2020" } } as unknown as Request;
@@ -274,11 +291,9 @@ describe("WineController", () => {
                     id: "region-1",
                     name: "Napa Valley"
                   },
-                  pricing: {
-                    glass: 16,
-                    bottle: 68
-                  },
-                  defaultVariation: null
+                  availableByBottle: true,
+                  availableByGlass: true,
+                  availableForFlight: false
                 }
               ]
             }

--- a/src/repositories/wine/IWineRepository.ts
+++ b/src/repositories/wine/IWineRepository.ts
@@ -1,4 +1,14 @@
-import type { Inventory, Prisma, Region, Wine, Winery, WineVariation } from "@prisma/client";
+import type {
+  Flight,
+  FlightWine,
+  Inventory,
+  Prisma,
+  Region,
+  Wine,
+  Winery,
+  WineVariation,
+  WineVariationServingMode
+} from "@prisma/client";
 
 export type WineWithRelations = Wine & {
   winery: Winery;
@@ -7,8 +17,12 @@ export type WineWithRelations = Wine & {
 
 export type WineWithInventory = WineWithRelations & {
   inventory?: Inventory[];
+  flightMemberships?: (FlightWine & {
+    flight: Pick<Flight, "isActive">;
+  })[];
   variations: (WineVariation & {
     inventory?: Inventory[];
+    servingModeConfig?: WineVariationServingMode | null;
   })[];
 };
 

--- a/src/repositories/wine/WineRepository.test.ts
+++ b/src/repositories/wine/WineRepository.test.ts
@@ -30,9 +30,21 @@ describe("WineRepository", () => {
         winery: true,
         region: true,
         inventory: true,
+        flightMemberships: {
+          include: {
+            flight: {
+              select: {
+                isActive: true
+              }
+            }
+          }
+        },
         variations: {
           where: {
             isPublic: true
+          },
+          include: {
+            servingModeConfig: true
           }
         }
       },
@@ -112,9 +124,21 @@ describe("WineRepository", () => {
         winery: true,
         region: true,
         inventory: true,
+        flightMemberships: {
+          include: {
+            flight: {
+              select: {
+                isActive: true
+              }
+            }
+          }
+        },
         variations: {
           where: {
             isPublic: true
+          },
+          include: {
+            servingModeConfig: true
           }
         }
       },
@@ -183,9 +207,21 @@ describe("WineRepository", () => {
         winery: true,
         region: true,
         inventory: true,
+        flightMemberships: {
+          include: {
+            flight: {
+              select: {
+                isActive: true
+              }
+            }
+          }
+        },
         variations: {
           where: {
             isPublic: true
+          },
+          include: {
+            servingModeConfig: true
           }
         }
       },
@@ -211,7 +247,20 @@ describe("WineRepository", () => {
         winery: true,
         region: true,
         inventory: true,
-        variations: true
+        flightMemberships: {
+          include: {
+            flight: {
+              select: {
+                isActive: true
+              }
+            }
+          }
+        },
+        variations: {
+          include: {
+            servingModeConfig: true
+          }
+        }
       }
     });
   });
@@ -268,7 +317,23 @@ describe("WineRepository", () => {
         winery: true,
         region: true,
         inventory: true,
-        variations: true
+        flightMemberships: {
+          include: {
+            flight: {
+              select: {
+                isActive: true
+              }
+            }
+          }
+        },
+        variations: {
+          where: {
+            isPublic: true
+          },
+          include: {
+            servingModeConfig: true
+          }
+        }
       }
     });
   });

--- a/src/repositories/wine/WineRepository.ts
+++ b/src/repositories/wine/WineRepository.ts
@@ -13,8 +13,20 @@ export class WineRepository implements IWineRepository {
         winery: true,
         region: true,
         inventory: true,
+        flightMemberships: {
+          include: {
+            flight: {
+              select: {
+                isActive: true
+              }
+            }
+          }
+        },
         variations: {
-          where: variationWhere
+          where: variationWhere,
+          include: {
+            servingModeConfig: true
+          }
         }
       },
       orderBy: { createdAt: "desc" }
@@ -28,7 +40,20 @@ export class WineRepository implements IWineRepository {
         winery: true,
         region: true,
         inventory: true,
-        variations: true
+        flightMemberships: {
+          include: {
+            flight: {
+              select: {
+                isActive: true
+              }
+            }
+          }
+        },
+        variations: {
+          include: {
+            servingModeConfig: true
+          }
+        }
       }
     });
   }
@@ -52,7 +77,23 @@ export class WineRepository implements IWineRepository {
         winery: true,
         region: true,
         inventory: true,
-        variations: true
+        flightMemberships: {
+          include: {
+            flight: {
+              select: {
+                isActive: true
+              }
+            }
+          }
+        },
+        variations: {
+          where: {
+            isPublic: true
+          },
+          include: {
+            servingModeConfig: true
+          }
+        }
       }
     });
   }

--- a/src/services/winePresentation.test.ts
+++ b/src/services/winePresentation.test.ts
@@ -1,7 +1,14 @@
 import { Decimal } from "@prisma/client/runtime/library";
 import { describe, expect, it } from "vitest";
 import type { WineWithInventory } from "@/repositories/wine/IWineRepository";
-import { compareWineListItems, inferWineType, toWineListItem, getDefaultVariation } from "@/services/winePresentation";
+import {
+  compareWineListItems,
+  getDefaultVariation,
+  inferWineType,
+  toPublicWineDetail,
+  toPublicWineListItem,
+  toWineListItem
+} from "@/services/winePresentation";
 
 function createWine(overrides: Partial<WineWithInventory> = {}): WineWithInventory {
   return {
@@ -447,5 +454,99 @@ describe("winePresentation", () => {
     const defaultVar = getDefaultVariation(wine);
 
     expect(defaultVar?.volumeOz).toBe(5);
+  });
+
+  it("maps public availability flags from serving modes", () => {
+    const wine = createWine({
+      variations: [
+        {
+          id: "var-private-bottle",
+          wineId: "w1",
+          squareVariationId: null,
+          name: "Private Bottle",
+          price: new Decimal(70),
+          volumeOz: 750,
+          isPublic: false,
+          isDefault: false,
+          createdAt: new Date("2026-03-19T00:00:00.000Z"),
+          servingModeConfig: {
+            servingMode: "BOTTLE_750ML",
+            isAvailable: true
+          } as never,
+          inventory: []
+        },
+        {
+          id: "var-unavailable-glass",
+          wineId: "w1",
+          squareVariationId: null,
+          name: "Glass",
+          price: new Decimal(16),
+          volumeOz: 5,
+          isPublic: true,
+          isDefault: false,
+          createdAt: new Date("2026-03-19T00:00:00.000Z"),
+          servingModeConfig: {
+            servingMode: "GLASS_5OZ",
+            isAvailable: false
+          } as never,
+          inventory: []
+        },
+        {
+          id: "var-bottle",
+          wineId: "w1",
+          squareVariationId: null,
+          name: "Bottle",
+          price: new Decimal(70),
+          volumeOz: 750,
+          isPublic: true,
+          isDefault: false,
+          createdAt: new Date("2026-03-19T00:00:00.000Z"),
+          servingModeConfig: {
+            servingMode: "BOTTLE_750ML",
+            isAvailable: true
+          } as never,
+          inventory: []
+        }
+      ]
+    });
+
+    const item = toPublicWineListItem(wine);
+
+    expect(item.availableByBottle).toBe(true);
+    expect(item.availableByGlass).toBe(false);
+    expect(item.availableForFlight).toBe(false);
+  });
+
+  it("marks availableForFlight when wine is in an active flight", () => {
+    const wine = createWine({
+      flightMemberships: [
+        {
+          id: "membership-1",
+          wineId: "w1",
+          flightId: "flight-1",
+          position: 0,
+          createdAt: new Date("2026-03-19T00:00:00.000Z"),
+          flight: {
+            isActive: true
+          }
+        }
+      ] as never,
+      variations: []
+    });
+
+    expect(toPublicWineListItem(wine).availableForFlight).toBe(true);
+  });
+
+  it("normalizes non-array grape varieties in public detail payload", () => {
+    const wine = createWine({
+      grapeVarieties: {
+        primary: "Cabernet"
+      } as never,
+      variations: []
+    });
+
+    const detail = toPublicWineDetail(wine);
+
+    expect(detail.grapeVarieties).toEqual([]);
   });
 });

--- a/src/services/winePresentation.ts
+++ b/src/services/winePresentation.ts
@@ -37,6 +37,32 @@ export type WineListItem = {
   defaultVariation: DefaultVariation | null;
 };
 
+export type PublicWineListItem = {
+  id: string;
+  slug: string;
+  name: string;
+  vintage: number;
+  country: string;
+  description: string;
+  imageUrl: string;
+  winery: {
+    id: string;
+    name: string;
+  };
+  region: {
+    id: string;
+    name: string;
+  };
+  availableByBottle: boolean;
+  availableByGlass: boolean;
+  availableForFlight: boolean;
+};
+
+export type PublicWineDetail = PublicWineListItem & {
+  grapeVarieties: string[];
+  alcoholPercent: number;
+};
+
 export function inferWineType(wine: WineWithInventory): WineType {
   const grapeVarieties = Array.isArray(wine.grapeVarieties)
     ? wine.grapeVarieties.filter((value): value is string => typeof value === "string")
@@ -157,6 +183,39 @@ export function compareWineListItems(
   return compareNullableNumbers(left.item.pricing.bottle, right.item.pricing.bottle, order);
 }
 
+export function toPublicWineListItem(wine: WineWithInventory): PublicWineListItem {
+  return {
+    id: wine.id,
+    slug: wine.slug,
+    name: wine.name,
+    vintage: wine.vintage,
+    country: wine.country,
+    description: wine.description,
+    imageUrl: wine.imageUrl,
+    winery: {
+      id: wine.winery.id,
+      name: wine.winery.name
+    },
+    region: {
+      id: wine.region.id,
+      name: wine.region.name
+    },
+    availableByBottle: hasAvailableServingMode(wine, ["BOTTLE_750ML"]),
+    availableByGlass: hasAvailableServingMode(wine, ["GLASS_5OZ", "GLASS_9OZ"]),
+    availableForFlight: hasAvailableServingMode(wine, ["FLIGHT_2OZ"]) || isInActiveFlight(wine)
+  };
+}
+
+export function toPublicWineDetail(wine: WineWithInventory): PublicWineDetail {
+  const item = toPublicWineListItem(wine);
+
+  return {
+    ...item,
+    grapeVarieties: normalizeGrapeVarieties(wine.grapeVarieties),
+    alcoholPercent: wine.alcoholPercent
+  };
+}
+
 function matchesAny(searchableText: string, candidates: string[]) {
   return candidates.some((candidate) => searchableText.includes(candidate));
 }
@@ -183,4 +242,31 @@ function compareNullableNumbers(left: number | null, right: number | null, order
   }
 
   return compareNumbers(left, right, order);
+}
+
+function hasAvailableServingMode(wine: WineWithInventory, servingModes: string[]) {
+  return wine.variations.some((variation) => {
+    if (!variation.isPublic) {
+      return false;
+    }
+
+    const servingModeConfig = variation.servingModeConfig;
+
+    return (
+      servingModeConfig?.isAvailable === true
+      && servingModes.includes(servingModeConfig.servingMode)
+    );
+  });
+}
+
+function isInActiveFlight(wine: WineWithInventory) {
+  return (wine.flightMemberships ?? []).some((membership) => membership.flight.isActive);
+}
+
+function normalizeGrapeVarieties(grapeVarieties: unknown): string[] {
+  if (!Array.isArray(grapeVarieties)) {
+    return [];
+  }
+
+  return grapeVarieties.filter((value): value is string => typeof value === "string");
 }

--- a/src/services/wineService.test.ts
+++ b/src/services/wineService.test.ts
@@ -206,16 +206,9 @@ describe("WineService", () => {
             id: "region-1",
             name: "Napa Valley"
           },
-          pricing: {
-            glass: 18,
-            bottle: 68
-          },
-          defaultVariation: {
-            id: "var-1",
-            name: "By the Glass",
-            price: 18,
-            volumeOz: 6
-          }
+          availableByBottle: false,
+          availableByGlass: false,
+          availableForFlight: false
         }
       ],
       page: 1,
@@ -226,7 +219,7 @@ describe("WineService", () => {
     expect(wineRepository.findMany).toHaveBeenCalledWith({});
   });
 
-  it("returns null pricing when a wine has no available inventory rows", async () => {
+  it("returns availability flags for wines in public list payloads", async () => {
     const { service, wineRepository } = createService();
     const wines: WineWithInventory[] = [
       {
@@ -280,11 +273,9 @@ describe("WineService", () => {
             id: "region-2",
             name: "Mosel"
           },
-          pricing: {
-            glass: null,
-            bottle: null
-          },
-          defaultVariation: null
+          availableByBottle: false,
+          availableByGlass: false,
+          availableForFlight: false
         }
       ],
       page: 1,
@@ -409,16 +400,9 @@ describe("WineService", () => {
             id: "region-1",
             name: "Napa Valley"
           },
-          pricing: {
-            glass: 20,
-            bottle: 80
-          },
-          defaultVariation: {
-            id: "var-1",
-            name: "By the Glass",
-            price: 20,
-            volumeOz: 6
-          }
+          availableByBottle: false,
+          availableByGlass: false,
+          availableForFlight: false
         }
       ],
       page: 2,
@@ -484,11 +468,9 @@ describe("WineService", () => {
             id: "region-1",
             name: "Napa Valley"
           },
-          pricing: {
-            glass: null,
-            bottle: null
-          },
-          defaultVariation: null
+          availableByBottle: false,
+          availableByGlass: false,
+          availableForFlight: false
         },
         {
           id: "w1",
@@ -506,11 +488,9 @@ describe("WineService", () => {
             id: "region-1",
             name: "Napa Valley"
           },
-          pricing: {
-            glass: null,
-            bottle: null
-          },
-          defaultVariation: null
+          availableByBottle: false,
+          availableByGlass: false,
+          availableForFlight: false
         }
       ],
       page: 1,
@@ -657,16 +637,9 @@ describe("WineService", () => {
                     id: "region-red",
                     name: "Napa Valley"
                   },
-                  pricing: {
-                    glass: 18,
-                    bottle: 72
-                  },
-                  defaultVariation: {
-                    id: "var-r1",
-                    name: "By the Glass",
-                    price: 18,
-                    volumeOz: 6
-                  }
+                  availableByBottle: false,
+                  availableByGlass: false,
+                  availableForFlight: false
                 }
               ]
             }
@@ -695,16 +668,9 @@ describe("WineService", () => {
                     id: "region-white",
                     name: "Rias Baixas"
                   },
-                  pricing: {
-                    glass: 15,
-                    bottle: 60
-                  },
-                  defaultVariation: {
-                    id: "var-w1",
-                    name: "By the Glass",
-                    price: 15,
-                    volumeOz: 6
-                  }
+                  availableByBottle: false,
+                  availableByGlass: false,
+                  availableForFlight: false
                 }
               ]
             }
@@ -752,11 +718,9 @@ describe("WineService", () => {
                     id: "region-1",
                     name: "Napa Valley"
                   },
-                  pricing: {
-                    glass: null,
-                    bottle: null
-                  },
-                  defaultVariation: null
+                  availableByBottle: false,
+                  availableByGlass: false,
+                  availableForFlight: false
                 }
               ]
             }
@@ -870,14 +834,14 @@ describe("WineService", () => {
   it("covers name and bottle sorting branches in compareWineListItems", () => {
     const { service } = createService();
     const compareWineListItems = service["compareWineListItems"].bind(service) as (
-      left: { wine: WineWithInventory; item: ReturnType<WineService["toWineListItem"]> },
-      right: { wine: WineWithInventory; item: ReturnType<WineService["toWineListItem"]> },
+      left: { wine: WineWithInventory; sortItem: ReturnType<WineService["toSortableWineListItem"]> },
+      right: { wine: WineWithInventory; sortItem: ReturnType<WineService["toSortableWineListItem"]> },
       sort: "createdAt" | "name" | "priceGlass" | "priceBottle",
       order: "asc" | "desc"
     ) => number;
-    const toWineListItem = service["toWineListItem"].bind(service) as (
+    const toSortableWineListItem = service["toSortableWineListItem"].bind(service) as (
       wine: WineWithInventory
-    ) => ReturnType<WineService["toWineListItem"]>;
+    ) => ReturnType<WineService["toSortableWineListItem"]>;
 
     const leftWine = createWineWithInventory();
     leftWine.name = "Merlot";
@@ -959,8 +923,8 @@ describe("WineService", () => {
 
     expect(
       compareWineListItems(
-        { wine: leftWine, item: toWineListItem(leftWine) },
-        { wine: rightWine, item: toWineListItem(rightWine) },
+        { wine: leftWine, sortItem: toSortableWineListItem(leftWine) },
+        { wine: rightWine, sortItem: toSortableWineListItem(rightWine) },
         "name",
         "desc"
       )
@@ -968,8 +932,8 @@ describe("WineService", () => {
 
     expect(
       compareWineListItems(
-        { wine: leftWine, item: toWineListItem(leftWine) },
-        { wine: rightWine, item: toWineListItem(rightWine) },
+        { wine: leftWine, sortItem: toSortableWineListItem(leftWine) },
+        { wine: rightWine, sortItem: toSortableWineListItem(rightWine) },
         "priceBottle",
         "asc"
       )
@@ -979,14 +943,14 @@ describe("WineService", () => {
   it("covers the createdAt sorting branch in compareWineListItems", () => {
     const { service } = createService();
     const compareWineListItems = service["compareWineListItems"].bind(service) as (
-      left: { wine: WineWithInventory; item: ReturnType<WineService["toWineListItem"]> },
-      right: { wine: WineWithInventory; item: ReturnType<WineService["toWineListItem"]> },
+      left: { wine: WineWithInventory; sortItem: ReturnType<WineService["toSortableWineListItem"]> },
+      right: { wine: WineWithInventory; sortItem: ReturnType<WineService["toSortableWineListItem"]> },
       sort: "createdAt" | "name" | "priceGlass" | "priceBottle",
       order: "asc" | "desc"
     ) => number;
-    const toWineListItem = service["toWineListItem"].bind(service) as (
+    const toSortableWineListItem = service["toSortableWineListItem"].bind(service) as (
       wine: WineWithInventory
-    ) => ReturnType<WineService["toWineListItem"]>;
+    ) => ReturnType<WineService["toSortableWineListItem"]>;
 
     const olderWine = createWineWithInventory();
     olderWine.createdAt = new Date("2026-03-18T00:00:00.000Z");
@@ -996,8 +960,8 @@ describe("WineService", () => {
 
     expect(
       compareWineListItems(
-        { wine: olderWine, item: toWineListItem(olderWine) },
-        { wine: newerWine, item: toWineListItem(newerWine) },
+        { wine: olderWine, sortItem: toSortableWineListItem(olderWine) },
+        { wine: newerWine, sortItem: toSortableWineListItem(newerWine) },
         "createdAt",
         "desc"
       )
@@ -1018,7 +982,28 @@ describe("WineService", () => {
 
     vi.mocked(wineRepository.findBySlugWithInventory).mockResolvedValue(wine);
 
-    await expect(service.getWineBySlug("cabernet-2020")).resolves.toEqual(wine);
+    await expect(service.getWineBySlug("cabernet-2020")).resolves.toEqual({
+      id: "w1",
+      slug: "cabernet-2020",
+      name: "Cabernet",
+      vintage: 2020,
+      country: "US",
+      description: "Bold",
+      imageUrl: "https://example.com/wine.png",
+      winery: {
+        id: "winery-1",
+        name: "Alpha Winery"
+      },
+      region: {
+        id: "region-1",
+        name: "Napa Valley"
+      },
+      availableByBottle: false,
+      availableByGlass: false,
+      availableForFlight: false,
+      grapeVarieties: ["Cabernet Sauvignon"],
+      alcoholPercent: 13.5
+    });
   });
 
   it("resolves QR code by slug when a slug match exists", async () => {

--- a/src/services/wineService.ts
+++ b/src/services/wineService.ts
@@ -5,34 +5,17 @@ import type { IWineryRepository } from "@/repositories/winery/IWineryRepository"
 import {
   compareWineListItems as compareWineListItemsForDisplay,
   inferWineType as inferWineTypeForDisplay,
+  toPublicWineDetail as toPublicWineDetailForDisplay,
+  toPublicWineListItem as toPublicWineListItemForDisplay,
   toWineListItem as toWineListItemForDisplay,
-  type DefaultVariation
+  type PublicWineDetail,
+  type PublicWineListItem,
+  type WineListItem as SortableWineListItem
 } from "@/services/winePresentation";
 import { AppError } from "@/utils/appError";
 import { normalizeSlugSegment } from "@/utils/slug";
 
-export type WineListItem = {
-  id: string;
-  slug: string;
-  name: string;
-  vintage: number;
-  country: string;
-  description: string;
-  imageUrl: string;
-  winery: {
-    id: string;
-    name: string;
-  };
-  region: {
-    id: string;
-    name: string;
-  };
-  pricing: {
-    glass: number | null;
-    bottle: number | null;
-  };
-  defaultVariation: DefaultVariation | null;
-};
+export type WineListItem = PublicWineListItem;
 
 export type WineType = "red" | "white" | "rose" | "sparkling" | "dessert" | "fortified" | "other";
 
@@ -98,7 +81,8 @@ export class WineService {
     const wines = await this.wineRepository.findMany(this.toWineListFilters(query));
     const sortableWines = wines.map((wine) => ({
       wine,
-      item: this.toWineListItem(wine)
+      sortItem: this.toSortableWineListItem(wine),
+      item: this.toPublicWineListItem(wine)
     }));
 
     sortableWines.sort((left, right) => this.compareWineListItems(left, right, query.sort, query.order));
@@ -130,7 +114,7 @@ export class WineService {
         wines: []
       };
 
-      region.wines.push(this.toWineListItem(wine));
+      region.wines.push(this.toPublicWineListItem(wine));
       regionMap.set(wine.region.id, region);
       groupedByType.set(wineType, regionMap);
     }
@@ -166,7 +150,7 @@ export class WineService {
       throw new AppError("Wine not found", 404);
     }
 
-    return wine;
+    return this.toPublicWineDetail(wine);
   }
 
   public async resolveWineSlugFromQrCode(code: string) {
@@ -259,12 +243,17 @@ export class WineService {
   }
 
   private compareWineListItems(
-    left: { wine: WineWithInventory; item: WineListItem },
-    right: { wine: WineWithInventory; item: WineListItem },
+    left: { wine: WineWithInventory; sortItem: SortableWineListItem },
+    right: { wine: WineWithInventory; sortItem: SortableWineListItem },
     sort: WineListSort,
     order: SortOrder
   ) {
-    return compareWineListItemsForDisplay(left, right, sort, order);
+    return compareWineListItemsForDisplay(
+      { wine: left.wine, item: left.sortItem },
+      { wine: right.wine, item: right.sortItem },
+      sort,
+      order
+    );
   }
 
   private compareNumbers(left: number, right: number, order: SortOrder) {
@@ -291,7 +280,15 @@ export class WineService {
     return this.compareNumbers(left, right, order);
   }
 
-  private toWineListItem(wine: WineWithInventory): WineListItem {
+  private toSortableWineListItem(wine: WineWithInventory): SortableWineListItem {
     return toWineListItemForDisplay(wine);
+  }
+
+  private toPublicWineListItem(wine: WineWithInventory): PublicWineListItem {
+    return toPublicWineListItemForDisplay(wine);
+  }
+
+  private toPublicWineDetail(wine: WineWithInventory): PublicWineDetail {
+    return toPublicWineDetailForDisplay(wine);
   }
 }


### PR DESCRIPTION
## Issues

Closes #42

## Summary

Updates public wine API contracts to expose boolean availability metadata for bottle, glass, and flight while removing pricing and inventory-level details from public payloads.

## Changes

- Add public wine payload mappers with availability flags:
  - `availableByBottle`
  - `availableByGlass`
  - `availableForFlight`
- Update wine list and grouped list responses to return public-facing DTOs without pricing/default variation fields
- Update wine detail response to return public-facing DTO without inventory counts or variation pricing
- Derive availability from serving mode configuration (`WineVariationServingMode`) and active flight membership
- Extend wine repository includes to load serving mode config and active flight membership for flag computation
- Update service/controller/repository tests for the new response contract
- Add test coverage for new availability-flag branches and grape variety normalization behavior

## Verification

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npx prisma validate`
- [ ] Relevant endpoint checks completed

## Checklist

- [x] No secrets were added
- [ ] README and docs updated (if needed)
- [x] Backward compatibility considered
