### PR TITLE
feat(Issue #9): Build embeddable grouped wine list UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ You can also run individual steps as needed.
 
 ### Wines
 
-- `GET /api/wines` - returns a paginated wine list with optional filters and summarized `pricing.glass` / `pricing.bottle` values
+- `GET /api/wines` - returns a paginated wine list with optional filters and public availability flags
 - `GET /api/wines/grouped` - returns wines grouped by inferred type, then by region
 - `GET /api/wines/:slug`
 - `GET /api/wines/qr/:code` - resolves a QR code token (slug or Square item id) and redirects to `/wines/:slug`
@@ -180,10 +180,9 @@ Example `GET /api/wines` response:
         "id": "region-1",
         "name": "Napa Valley"
       },
-      "pricing": {
-        "glass": 16,
-        "bottle": 68
-      }
+      "availableByBottle": true,
+      "availableByGlass": true,
+      "availableForFlight": false
     }
   ],
   "page": 1,
@@ -227,10 +226,9 @@ Example `GET /api/wines/grouped` response:
                 "id": "region-1",
                 "name": "Napa Valley"
               },
-              "pricing": {
-                "glass": 16,
-                "bottle": 68
-              }
+              "availableByBottle": true,
+              "availableByGlass": true,
+              "availableForFlight": false
             }
           ]
         }
@@ -239,6 +237,46 @@ Example `GET /api/wines/grouped` response:
   ],
   "totalWines": 1
 }
+```
+
+## Embeddable Wine List
+
+The embeddable wine list is available at `GET /embed/wine-list` and loads grouped wines from `GET /api/wines/grouped`.
+
+### Iframe Embed
+
+```html
+<iframe
+  src="https://your-domain.example/embed/wine-list"
+  style="width:100%;height:780px;border:0;display:block"
+  loading="lazy"
+></iframe>
+```
+
+Optional compact mode:
+
+```html
+<iframe
+  src="https://your-domain.example/embed/wine-list?compact=true"
+  style="width:100%;height:700px;border:0;display:block"
+  loading="lazy"
+></iframe>
+```
+
+### Script Embed
+
+Load the helper script and mount the iframe programmatically:
+
+```html
+<div id="pourhouse-wine-list"></div>
+<script src="https://your-domain.example/static/wine-list-embed-loader.js"></script>
+<script>
+  window.createPourhouseWineListEmbed(document.getElementById("pourhouse-wine-list"), {
+    baseUrl: "https://your-domain.example",
+    compact: false,
+    height: "780px"
+  });
+</script>
 ```
 
 Example `POST /api/wines` request body:

--- a/public/wine-list-embed-loader.js
+++ b/public/wine-list-embed-loader.js
@@ -1,0 +1,36 @@
+function createPourhouseWineListEmbed(target, options) {
+  if (!target) {
+    return null
+  }
+
+  const settings = options || {}
+  const baseUrl = (settings.baseUrl || window.location.origin || "").replace(/\/$/, "")
+  const compact = settings.compact === true
+  const apiBase = typeof settings.apiBase === "string" ? settings.apiBase : ""
+
+  const src = new URL(`${baseUrl}/embed/wine-list`)
+
+  if (compact) {
+    src.searchParams.set("compact", "true")
+  }
+
+  if (apiBase) {
+    src.searchParams.set("apiBase", apiBase)
+  }
+
+  const iframe = document.createElement("iframe")
+  iframe.src = src.toString()
+  iframe.loading = "lazy"
+  iframe.referrerPolicy = "strict-origin-when-cross-origin"
+  iframe.style.width = settings.width || "100%"
+  iframe.style.height = settings.height || "780px"
+  iframe.style.border = "0"
+  iframe.style.display = "block"
+
+  target.innerHTML = ""
+  target.appendChild(iframe)
+
+  return iframe
+}
+
+window.createPourhouseWineListEmbed = createPourhouseWineListEmbed

--- a/public/wine-list-embed.css
+++ b/public/wine-list-embed.css
@@ -1,0 +1,234 @@
+:root {
+  --paper: #f6f1e7;
+  --ink: #1d1d1a;
+  --ink-soft: #585752;
+  --line: rgba(29, 29, 26, 0.16);
+  --accent: #b44f2e;
+  --accent-soft: rgba(180, 79, 46, 0.14);
+  --glass: #2f6c61;
+  --bottle: #7d2435;
+  --flight: #3d4d9c;
+  --card: rgba(255, 255, 255, 0.84);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  font-family: "Manrope", "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(90% 80% at 0% 0%, #ffd7ab 0%, rgba(255, 215, 171, 0) 55%),
+    radial-gradient(90% 80% at 100% 100%, #c4dece 0%, rgba(196, 222, 206, 0) 50%),
+    linear-gradient(160deg, #f4ecdd 0%, #f1e4cf 48%, #e6d8be 100%);
+}
+
+.embed-shell {
+  min-height: 100vh;
+  padding: 18px;
+}
+
+.embed-shell[data-compact="true"] {
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.hero {
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  background: var(--card);
+  backdrop-filter: blur(3px);
+  box-shadow: 0 12px 34px rgba(22, 22, 20, 0.14);
+  padding: 18px;
+}
+
+.hero p {
+  margin: 0;
+}
+
+.kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.72rem;
+  color: var(--ink-soft);
+  font-weight: 700;
+}
+
+.hero h1 {
+  margin: 10px 0 8px;
+  font-family: "Prata", Georgia, serif;
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  line-height: 1.08;
+}
+
+.subtitle {
+  color: var(--ink-soft);
+  line-height: 1.52;
+}
+
+.state-card {
+  border-radius: 20px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  padding: 20px;
+}
+
+.state-card h1 {
+  margin: 8px 0 8px;
+  font-family: "Prata", Georgia, serif;
+  font-size: clamp(1.5rem, 3.5vw, 2.2rem);
+}
+
+.state-kicker {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.72rem;
+  color: var(--ink-soft);
+  font-weight: 700;
+}
+
+.state-card--error {
+  border-color: rgba(180, 79, 46, 0.3);
+  background: linear-gradient(180deg, rgba(255, 251, 247, 0.92), rgba(255, 234, 223, 0.9));
+}
+
+.groups {
+  margin-top: 14px;
+  display: grid;
+  gap: 14px;
+}
+
+.type-block {
+  border-radius: 18px;
+  border: 1px solid var(--line);
+  background: var(--card);
+  box-shadow: 0 10px 24px rgba(21, 21, 19, 0.08);
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(8px);
+  animation: blockIn 280ms ease-out forwards;
+}
+
+.type-head {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.66), rgba(255, 255, 255, 0.2));
+}
+
+.type-head h2 {
+  margin: 0;
+  font-family: "Prata", Georgia, serif;
+  font-size: 1.3rem;
+  text-transform: capitalize;
+}
+
+.region {
+  padding: 14px 16px;
+  border-bottom: 1px dashed var(--line);
+}
+
+.region:last-child {
+  border-bottom: 0;
+}
+
+.region h3 {
+  margin: 0 0 10px;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.wine-grid {
+  display: grid;
+  gap: 8px;
+}
+
+.wine-card {
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.62);
+  padding: 10px;
+}
+
+.wine-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.wine-meta {
+  margin: 4px 0 0;
+  color: var(--ink-soft);
+  font-size: 0.9rem;
+}
+
+.badges {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.badge {
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  border: 1px solid transparent;
+}
+
+.badge--glass {
+  background: color-mix(in srgb, var(--glass) 16%, white);
+  border-color: color-mix(in srgb, var(--glass) 28%, white);
+  color: var(--glass);
+}
+
+.badge--bottle {
+  background: color-mix(in srgb, var(--bottle) 14%, white);
+  border-color: color-mix(in srgb, var(--bottle) 30%, white);
+  color: var(--bottle);
+}
+
+.badge--flight {
+  background: color-mix(in srgb, var(--flight) 16%, white);
+  border-color: color-mix(in srgb, var(--flight) 30%, white);
+  color: var(--flight);
+}
+
+.badge--out {
+  background: rgba(0, 0, 0, 0.05);
+  border-color: rgba(0, 0, 0, 0.08);
+  color: var(--ink-soft);
+}
+
+@keyframes blockIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (min-width: 720px) {
+  .embed-shell {
+    padding: 22px;
+  }
+
+  .groups {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/public/wine-list-embed.html
+++ b/public/wine-list-embed.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pourhouse Wine List</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Prata&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/static/wine-list-embed.css">
+</head>
+<body>
+  <main class="embed-shell" id="wine-list-embed-root" aria-live="polite">
+    <section class="state-card state-card--loading">
+      <p class="state-kicker">Pourhouse</p>
+      <h1>Loading the wine list</h1>
+      <p>Gathering current wines by type and region.</p>
+    </section>
+  </main>
+  <script src="/static/wine-list-embed.js" defer></script>
+</body>
+</html>

--- a/public/wine-list-embed.js
+++ b/public/wine-list-embed.js
@@ -1,0 +1,162 @@
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+}
+
+function queryBoolean(value) {
+  if (value === null) {
+    return false
+  }
+
+  return value === "1" || value.toLowerCase() === "true"
+}
+
+function getEmbedOptions() {
+  const params = new URLSearchParams(window.location.search)
+
+  return {
+    compact: queryBoolean(params.get("compact")),
+    apiBase: (params.get("apiBase") || "").trim()
+  }
+}
+
+function endpointFromBase(apiBase) {
+  if (!apiBase) {
+    return "/api/wines/grouped"
+  }
+
+  return `${apiBase.replace(/\/$/, "")}/api/wines/grouped`
+}
+
+function renderError(message) {
+  const root = document.getElementById("wine-list-embed-root")
+  if (!root) {
+    return
+  }
+
+  root.innerHTML = `
+    <section class="state-card state-card--error">
+      <p class="state-kicker">Pourhouse</p>
+      <h1>Unable to load wine list</h1>
+      <p>${escapeHtml(message)}</p>
+    </section>
+  `
+}
+
+function badges(wine) {
+  const items = []
+
+  if (wine.availableByGlass) {
+    items.push("<span class=\"badge badge--glass\">By the Glass</span>")
+  }
+
+  if (wine.availableByBottle) {
+    items.push("<span class=\"badge badge--bottle\">Bottle Pour</span>")
+  }
+
+  if (wine.availableForFlight) {
+    items.push("<span class=\"badge badge--flight\">Flight Featured</span>")
+  }
+
+  if (items.length === 0) {
+    items.push("<span class=\"badge badge--out\">Temporarily Unavailable</span>")
+  }
+
+  return items.join("")
+}
+
+function renderGroupedList(payload, options) {
+  const root = document.getElementById("wine-list-embed-root")
+  if (!root) {
+    return
+  }
+
+  const groups = Array.isArray(payload.groups) ? payload.groups : []
+
+  if (groups.length === 0) {
+    root.innerHTML = `
+      <section class="state-card">
+        <p class="state-kicker">Pourhouse</p>
+        <h1>No wines published yet</h1>
+        <p>Check back shortly for the latest list.</p>
+      </section>
+    `
+
+    return
+  }
+
+  root.dataset.compact = options.compact ? "true" : "false"
+
+  const hero = options.compact
+    ? ""
+    : `
+      <section class=\"hero\">
+        <p class=\"kicker\">Pourhouse Wine Co.</p>
+        <h1>Current Wine List</h1>
+        <p class=\"subtitle\">Explore our pours by style and region.</p>
+      </section>
+    `
+
+  const groupsMarkup = groups
+    .map((group, groupIndex) => {
+      const regions = Array.isArray(group.regions) ? group.regions : []
+
+      const regionsMarkup = regions
+        .map((region) => {
+          const wines = Array.isArray(region.wines) ? region.wines : []
+
+          const winesMarkup = wines
+            .map((wine) => `
+              <article class=\"wine-card\">
+                <h4 class=\"wine-title\">${escapeHtml(wine.name)} ${escapeHtml(wine.vintage)}</h4>
+                <p class=\"wine-meta\">${escapeHtml(wine.winery.name)} · ${escapeHtml(wine.country)}</p>
+                <div class=\"badges\">${badges(wine)}</div>
+              </article>
+            `)
+            .join("")
+
+          return `
+            <section class=\"region\">
+              <h3>${escapeHtml(region.name)}</h3>
+              <div class=\"wine-grid\">${winesMarkup}</div>
+            </section>
+          `
+        })
+        .join("")
+
+      return `
+        <article class=\"type-block\" style=\"animation-delay:${groupIndex * 60}ms\">
+          <header class=\"type-head\">
+            <h2>${escapeHtml(group.type)}</h2>
+          </header>
+          ${regionsMarkup}
+        </article>
+      `
+    })
+    .join("")
+
+  root.innerHTML = `${hero}<section class=\"groups\">${groupsMarkup}</section>`
+}
+
+async function loadEmbeddedWineList() {
+  const options = getEmbedOptions()
+
+  try {
+    const response = await fetch(endpointFromBase(options.apiBase))
+
+    if (!response.ok) {
+      throw new Error(`Request failed (${response.status})`)
+    }
+
+    const payload = await response.json()
+    renderGroupedList(payload, options)
+  } catch {
+    renderError("Please try again in a moment.")
+  }
+}
+
+void loadEmbeddedWineList()

--- a/src/routes/frontendRoutes.ts
+++ b/src/routes/frontendRoutes.ts
@@ -3,9 +3,14 @@ import { Router } from "express";
 
 const router = Router();
 const wineDetailPage = path.resolve(process.cwd(), "public", "wine-detail.html");
+const wineListEmbedPage = path.resolve(process.cwd(), "public", "wine-list-embed.html");
 
 router.get("/wines/:slug", (_req, res) => {
   res.sendFile(wineDetailPage);
+});
+
+router.get("/embed/wine-list", (_req, res) => {
+  res.sendFile(wineListEmbedPage);
 });
 
 export default router;

--- a/src/routes/index.test.ts
+++ b/src/routes/index.test.ts
@@ -26,4 +26,21 @@ describe("routes index", () => {
     expect(response.headers["content-type"]).toContain("javascript");
     expect(response.text).toContain("loadWineBySlug");
   });
+
+  it("serves the embeddable wine list shell", async () => {
+    const response = await request(app).get("/embed/wine-list");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.text).toContain("id=\"wine-list-embed-root\"");
+    expect(response.text).toContain("/static/wine-list-embed.js");
+  });
+
+  it("serves embeddable wine list static assets", async () => {
+    const response = await request(app).get("/static/wine-list-embed-loader.js");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("javascript");
+    expect(response.text).toContain("createPourhouseWineListEmbed");
+  });
 });


### PR DESCRIPTION
## Issues

Closes #9

## Summary

Builds an embeddable wine list UI that can be dropped into Squarespace via iframe or script. The embed fetches grouped wines from the backend API and renders a mobile-first presentation grouped by type and region with availability badges.

## Changes

- Add new frontend route `GET /embed/wine-list` to serve the embeddable shell
- Add new static embed shell and assets:
  - `public/wine-list-embed.html`
  - `public/wine-list-embed.css`
  - `public/wine-list-embed.js`
  - `public/wine-list-embed-loader.js`
- Implement grouped-list rendering from `GET /api/wines/grouped`
- Add loading, empty, and error states for embed resilience
- Add mobile-first responsive layout and compact-mode support via `?compact=true`
- Add script-based embed helper `window.createPourhouseWineListEmbed(...)` for host pages
- Extend route tests to verify:
  - embed shell is served
  - loader script asset is served
- Update `README.md` with:
  - current wine API public response examples
  - iframe embed example
  - script embed example

## Verification

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npx prisma validate`
- [ ] Relevant endpoint checks completed

## Checklist

- [x] No secrets were added
- [x] README and docs updated (if needed)
- [x] Backward compatibility considered
