### PR TITLE
[AUTH] Migrate all authentication to Google OAuth/OIDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,6 @@ Seed includes:
 - Wineries
 - Wines
 - Inventory records
-- Default user (`admin@pourhousewineco.com`, password `password123`)
+- Default user email (`admin@pourhousewineco.com`) for Google identity linking and role assignment
 
-Change seeded credentials before production use.
+Grant or revoke admin access with `npm run admin:grant -- <email>` and `npm run admin:revoke -- <email>`.

--- a/docs/database.md
+++ b/docs/database.md
@@ -81,9 +81,9 @@ The seed script at `prisma/seed.ts` populates the database with initial referenc
 - Wineries
 - Wines
 - Inventory records
-- Default user (`admin@pourhousewineco.com`, password `password123`)
+- Default user email (`admin@pourhousewineco.com`) for Google identity linking and role assignment
 
-> Change the seeded credentials before deploying to any shared or production environment.
+> Use the admin role scripts to grant/revoke admin access as needed.
 
 Run the seed:
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,4 @@
 import { PrismaClient } from "@prisma/client";
-import bcrypt from "bcrypt";
 import dotenv from "dotenv";
 
 dotenv.config();
@@ -131,14 +130,12 @@ async function main() {
     skipDuplicates: true
   });
 
-  const passwordHash = await bcrypt.hash("password123", 10);
-
   await prisma.user.upsert({
     where: { email: "admin@pourhousewineco.com" },
     update: {},
     create: {
       email: "admin@pourhousewineco.com",
-      password: passwordHash,
+      password: null,
       name: "Pourhouse Admin"
     }
   });

--- a/src/services/authService.test.ts
+++ b/src/services/authService.test.ts
@@ -227,6 +227,7 @@ describe("GoogleAuthClient", () => {
   });
 
   it("verifies token info and returns identity", async () => {
+    const exp = `${Math.floor(Date.now() / 1000) + 600}`;
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({
@@ -235,6 +236,7 @@ describe("GoogleAuthClient", () => {
         sub: "google-sub-1",
         email: "user@example.com",
         email_verified: "true",
+        exp,
         name: "User"
       })
     }) as never;
@@ -250,6 +252,7 @@ describe("GoogleAuthClient", () => {
   });
 
   it("supports alternate valid issuer and falls back name to email", async () => {
+    const exp = `${Math.floor(Date.now() / 1000) + 600}`;
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({
@@ -257,7 +260,8 @@ describe("GoogleAuthClient", () => {
         aud: "google-client-id-test",
         sub: "google-sub-1",
         email: "user@example.com",
-        email_verified: "true"
+        email_verified: "true",
+        exp
       })
     }) as never;
 
@@ -284,6 +288,7 @@ describe("GoogleAuthClient", () => {
   });
 
   it("throws when token info has invalid issuer or audience", async () => {
+    const exp = `${Math.floor(Date.now() / 1000) + 600}`;
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({
@@ -291,7 +296,8 @@ describe("GoogleAuthClient", () => {
         aud: "google-client-id-test",
         sub: "google-sub-1",
         email: "user@example.com",
-        email_verified: "true"
+        email_verified: "true",
+        exp
       })
     }) as never;
 
@@ -303,6 +309,7 @@ describe("GoogleAuthClient", () => {
   });
 
   it("throws when token info audience does not match client id", async () => {
+    const exp = `${Math.floor(Date.now() / 1000) + 600}`;
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({
@@ -310,7 +317,8 @@ describe("GoogleAuthClient", () => {
         aud: "different-client-id",
         sub: "google-sub-1",
         email: "user@example.com",
-        email_verified: "true"
+        email_verified: "true",
+        exp
       })
     }) as never;
 
@@ -322,6 +330,7 @@ describe("GoogleAuthClient", () => {
   });
 
   it("throws when required verified identity fields are missing", async () => {
+    const exp = `${Math.floor(Date.now() / 1000) + 600}`;
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: vi.fn().mockResolvedValue({
@@ -329,7 +338,8 @@ describe("GoogleAuthClient", () => {
         aud: "google-client-id-test",
         sub: "google-sub-1",
         email: "user@example.com",
-        email_verified: "false"
+        email_verified: "false",
+        exp
       })
     }) as never;
 
@@ -337,6 +347,46 @@ describe("GoogleAuthClient", () => {
 
     await expect(client.verifyIdToken("id-token")).rejects.toEqual(
       new AppError("Google account is missing required verified identity fields", 401)
+    );
+  });
+
+  it("throws when token is expired", async () => {
+    const exp = `${Math.floor(Date.now() / 1000) - 60}`;
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        iss: "https://accounts.google.com",
+        aud: "google-client-id-test",
+        sub: "google-sub-1",
+        email: "user@example.com",
+        email_verified: "true",
+        exp
+      })
+    }) as never;
+
+    const client = new GoogleAuthClient();
+
+    await expect(client.verifyIdToken("id-token")).rejects.toEqual(
+      new AppError("Google token validation failed", 401)
+    );
+  });
+
+  it("throws when token info payload does not include expiry", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        iss: "https://accounts.google.com",
+        aud: "google-client-id-test",
+        sub: "google-sub-1",
+        email: "user@example.com",
+        email_verified: "true"
+      })
+    }) as never;
+
+    const client = new GoogleAuthClient();
+
+    await expect(client.verifyIdToken("id-token")).rejects.toEqual(
+      new AppError("Google token validation failed", 401)
     );
   });
 });

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -13,6 +13,7 @@ type GoogleTokenInfoResponse = {
   sub?: string;
   email?: string;
   email_verified?: string;
+  exp?: string;
   name?: string;
 };
 
@@ -79,8 +80,11 @@ export class GoogleAuthClient implements IGoogleAuthClient {
 
     const isValidIssuer = payload.iss === "accounts.google.com"
       || payload.iss === "https://accounts.google.com";
+    const tokenExpiry = Number(payload.exp);
+    const nowUnixSeconds = Math.floor(Date.now() / 1000);
+    const hasValidExpiry = Number.isFinite(tokenExpiry) && tokenExpiry > nowUnixSeconds;
 
-    if (!isValidIssuer || payload.aud !== env.GOOGLE_CLIENT_ID) {
+    if (!isValidIssuer || payload.aud !== env.GOOGLE_CLIENT_ID || !hasValidExpiry) {
       throw new AppError("Google token validation failed", 401);
     }
 


### PR DESCRIPTION
## Issues

Closes #58

## Summary

Completes the Google-only authentication migration hardening by enforcing ID token expiry validation, removing password-oriented seed behavior, and updating docs to reflect Google identity linking and role-based admin onboarding.

## Changes

- Added explicit Google ID token expiry validation in `GoogleAuthClient.verifyIdToken`.
- Expanded auth test coverage for expiry behavior, including expired and missing-expiry token payloads.
- Updated seed data to stop generating/storing a default password hash for the seeded admin user.
- Updated docs to remove stale password login guidance and document Google identity linking + admin role script usage.

## Verification

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npx prisma validate`
- [x] Relevant endpoint checks completed

## Checklist

- [x] No secrets were added
- [x] README and docs updated (if needed)
- [x] Backward compatibility considered
