### PR TITLE
[ADMIN] Unit and integration tests for admin wine editor

### DIFF
--- a/src/routes/adminReferenceRoutes.test.ts
+++ b/src/routes/adminReferenceRoutes.test.ts
@@ -1,0 +1,52 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+const listAdminWineOptions = vi.hoisted(() => vi.fn((_req, res) => {
+  res.status(200).json({
+    regions: [{ id: "region-1", name: "Napa" }],
+    wineries: [{ id: "winery-1", name: "Alpha" }]
+  });
+}));
+
+vi.mock("@/controllers/adminReferenceController", () => ({
+  listAdminWineOptions
+}));
+
+vi.mock("@/container", () => ({
+  adminAuthMiddleware: (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (req.headers.authorization !== "Bearer admin-token") {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    next();
+  }
+}));
+
+import router from "@/routes/adminReferenceRoutes";
+
+describe("adminReferenceRoutes", () => {
+  const app = express();
+  app.use(router);
+
+  it("rejects unauthenticated requests", async () => {
+    const response = await request(app).get("/wine-options");
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ message: "Unauthorized" });
+  });
+
+  it("routes authenticated GET /wine-options to listAdminWineOptions", async () => {
+    const response = await request(app)
+      .get("/wine-options")
+      .set("Authorization", "Bearer admin-token");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      regions: [{ id: "region-1", name: "Napa" }],
+      wineries: [{ id: "winery-1", name: "Alpha" }]
+    });
+    expect(listAdminWineOptions).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/routes/adminWineRoutes.test.ts
+++ b/src/routes/adminWineRoutes.test.ts
@@ -1,0 +1,97 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+const {
+  listWines,
+  createWine,
+  updateWine,
+  deleteWine
+} = vi.hoisted(() => ({
+  listWines: vi.fn((_req, res) => {
+    res.status(200).json([{ id: "wine-1" }]);
+  }),
+  createWine: vi.fn((_req, res) => {
+    res.status(201).json({ id: "wine-2" });
+  }),
+  updateWine: vi.fn((_req, res) => {
+    res.status(200).json({ id: "wine-3" });
+  }),
+  deleteWine: vi.fn((_req, res) => {
+    res.status(204).send();
+  })
+}));
+
+vi.mock("@/controllers/adminWineController", () => ({
+  listWines,
+  createWine,
+  updateWine,
+  deleteWine
+}));
+
+vi.mock("@/container", () => ({
+  adminAuthMiddleware: (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (req.headers.authorization !== "Bearer admin-token") {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    next();
+  }
+}));
+
+import router from "@/routes/adminWineRoutes";
+
+describe("adminWineRoutes", () => {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+
+  it("rejects unauthenticated requests", async () => {
+    const response = await request(app).get("/");
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ message: "Unauthorized" });
+  });
+
+  it("routes authenticated GET / to listWines", async () => {
+    const response = await request(app)
+      .get("/")
+      .set("Authorization", "Bearer admin-token");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([{ id: "wine-1" }]);
+    expect(listWines).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes authenticated POST / to createWine", async () => {
+    const response = await request(app)
+      .post("/")
+      .set("Authorization", "Bearer admin-token")
+      .send({ name: "New wine" });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({ id: "wine-2" });
+    expect(createWine).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes authenticated PUT /:id to updateWine", async () => {
+    const response = await request(app)
+      .put("/wine-3")
+      .set("Authorization", "Bearer admin-token")
+      .send({ name: "Updated" });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ id: "wine-3" });
+    expect(updateWine).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes authenticated DELETE /:id to deleteWine", async () => {
+    const response = await request(app)
+      .delete("/wine-4")
+      .set("Authorization", "Bearer admin-token");
+
+    expect(response.status).toBe(204);
+    expect(deleteWine).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/routes/frontendRoutes.test.ts
+++ b/src/routes/frontendRoutes.test.ts
@@ -1,0 +1,36 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import frontendRoutes from "@/routes/frontendRoutes";
+
+describe("frontendRoutes", () => {
+  const app = express();
+  app.use(frontendRoutes);
+
+  it("serves admin wines frontend with core editor controls", async () => {
+    const response = await request(app).get("/admin/wines");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.text).toContain("id=\"admin-wines-root\"");
+    expect(response.text).toContain("id=\"google-signin\"");
+    expect(response.text).toContain("id=\"wine-form\"");
+    expect(response.text).toContain("id=\"wine-list\"");
+  });
+
+  it("serves wine detail frontend shell", async () => {
+    const response = await request(app).get("/wines/test-wine");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.text).toContain("id=\"wine-detail-root\"");
+  });
+
+  it("serves embeddable wine list frontend shell", async () => {
+    const response = await request(app).get("/embed/wine-list");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.text).toContain("id=\"wine-list-embed-root\"");
+  });
+});


### PR DESCRIPTION
## Issues

Closes #54

## Summary

Adds comprehensive admin editor test coverage across backend admin routes and frontend admin shell serving behavior. This closes missing integration coverage around route protection, handler wiring, and frontend editor shell availability.

## Changes

- Added integration tests for admin wine routes to verify unauthorized rejection and authenticated handler routing for list/create/update/delete.
- Added integration tests for admin reference routes to verify unauthorized rejection and authenticated wine-options routing.
- Added frontend route tests to verify admin, wine detail, and embed shells are served with expected core HTML controls.
- Kept existing backend unit tests intact and validated full-suite coverage gates.

## Verification

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npx prisma validate`
- [x] Relevant endpoint checks completed

## Checklist

- [x] No secrets were added
- [x] README and docs updated (if needed)
- [x] Backward compatibility considered
