### PR TITLE
feat: add scheduled Square sync job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,5 @@ GOOGLE_REDIRECT_URI="http://localhost:4000/auth/google/callback"
 # Square API
 SQUARE_ACCESS_TOKEN="replace-with-square-access-token"
 SQUARE_ENVIRONMENT="production"
+SQUARE_SYNC_ENABLED="false"
+SQUARE_SYNC_CRON="*/10 * * * *"

--- a/.github/.tmp_pr_body.md
+++ b/.github/.tmp_pr_body.md
@@ -1,19 +1,27 @@
 ## Issues
 
-Closes #43
+Closes #5
 
 ## Summary
 
-Implements the pre-production Prisma migration rebaseline workflow by replacing historical migrations with a single baseline migration, documenting rollout expectations, and updating CI to apply migrations in deploy mode.
+Implements a scheduled Square-to-database sync job with cron-based intervals, startup/shutdown lifecycle handling, idempotent run protection, structured logging, and full unit coverage.
 
 ## Changes
 
-- Added one baseline migration at `prisma/migrations/20260413150000_baseline/migration.sql` generated from current schema.
-- Removed prior migration files so history starts from the new baseline.
-- Added dev database safety backup file at `prisma/backups/dev-schema-backup-issue43.sql`.
-- Updated database rebaseline and first production deploy guidance in `docs/database.md`.
-- Updated setup/scripts guidance in `README.md` to include deploy-mode migrations.
-- Updated CI workflow to run `npx prisma migrate deploy` before build.
+- Added scheduler core in `src/integrations/square/squareSyncJob.ts` with:
+	- cron scheduling support using `node-cron`
+	- overlap prevention (skip if prior run still in progress)
+	- run start/completion/failure logging
+	- one-shot runner utility for reuse
+- Added runtime wiring in `src/integrations/square/squareSyncScheduler.ts` to connect existing `SquareCatalogService` and `SquareWineSyncService`.
+- Wired scheduler lifecycle in `src/server.ts` (start on boot, stop on `SIGINT`/`SIGTERM`).
+- Added environment configuration:
+	- `SQUARE_SYNC_ENABLED`
+	- `SQUARE_SYNC_CRON`
+- Updated env parsing defaults in `src/config/env.ts` and test defaults in `src/config/testEnv.ts`.
+- Added focused tests in `src/integrations/square/squareSyncJob.test.ts` for enable/disable behavior, overlap handling, error logging, and cron validation.
+- Updated `.env.example`, `docs/environment.md`, and `README.md` to document scheduler setup and behavior.
+- Added `node-cron` dependency in `package.json` and `package-lock.json`.
 
 ## Verification
 
@@ -21,7 +29,7 @@ Implements the pre-production Prisma migration rebaseline workflow by replacing 
 - [x] `npm run test`
 - [x] `npm run test:coverage`
 - [x] `npx prisma validate`
-- [ ] Relevant endpoint checks completed
+- [x] Relevant endpoint checks completed
 
 ## Checklist
 

--- a/README.md
+++ b/README.md
@@ -120,8 +120,18 @@ Use `.env.example` as a template:
 - `GOOGLE_REDIRECT_URI`
 - `SQUARE_ACCESS_TOKEN`
 - `SQUARE_ENVIRONMENT`
+- `SQUARE_SYNC_ENABLED`
+- `SQUARE_SYNC_CRON`
 
 For sample-data seeding workflows, set `SQUARE_ENVIRONMENT=sandbox` and use a Square sandbox access token.
+
+## Scheduled Square Sync
+
+The API supports a background scheduler that fetches Square catalog data and syncs it into local wines/inventory.
+
+- Set `SQUARE_SYNC_ENABLED=true` to turn on the scheduler.
+- Set `SQUARE_SYNC_CRON` to control the interval (default: `*/10 * * * *`, every 10 minutes).
+- Each run logs start, completion summary (created/updated/skipped/inventoryRowsSynced), and failures.
 
 ## Sample Data Seeding
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -30,6 +30,8 @@ cp .env.example .env
 | `GOOGLE_REDIRECT_URI` | Yes | — | Callback URL registered in Google Cloud Console for the auth code flow. |
 | `SQUARE_ACCESS_TOKEN` | Yes | — | Access token used for Square catalog API requests and sync operations. |
 | `SQUARE_ENVIRONMENT` | No | `production` | Square environment selector. Accepted values: `sandbox`, `production`. |
+| `SQUARE_SYNC_ENABLED` | No | `false` | Enables the background Square-to-database sync scheduler when set to `true`. |
+| `SQUARE_SYNC_CRON` | No | `*/10 * * * *` | Cron expression used by the Square sync scheduler (default is every 10 minutes). |
 
 ## Adding a New Variable
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "helmet": "8.1.0",
         "jsonwebtoken": "9.0.3",
         "morgan": "1.10.1",
+        "node-cron": "4.2.1",
         "square": "44.0.1",
         "zod": "4.3.6"
       },
@@ -4576,6 +4577,14 @@
       "integrity": "sha512-gBVjCaqDlRUk0EwoPNKzIr9KkS9041G/q31IBShPs1Xz6UTA+EXdZADbzqAJQrpDRq71CIMnOP5VMut3SL0z5Q==",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "helmet": "8.1.0",
     "jsonwebtoken": "9.0.3",
     "morgan": "1.10.1",
+    "node-cron": "4.2.1",
     "square": "44.0.1",
     "zod": "4.3.6"
   },

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -3,6 +3,11 @@ import { z } from "zod";
 
 dotenv.config();
 
+const booleanEnvSchema = z
+  .enum(["true", "false"])
+  .default("false")
+  .transform((value) => value === "true");
+
 const envSchema = z.object({
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
   PORT: z.coerce.number().int().positive().default(4000),
@@ -13,7 +18,10 @@ const envSchema = z.object({
   GOOGLE_CLIENT_SECRET: z.string().min(1, "GOOGLE_CLIENT_SECRET is required"),
   GOOGLE_REDIRECT_URI: z.string().url("GOOGLE_REDIRECT_URI must be a valid URL"),
   SQUARE_ACCESS_TOKEN: z.string().min(1, "SQUARE_ACCESS_TOKEN is required"),
-  SQUARE_ENVIRONMENT: z.enum(["sandbox", "production"]).default("production")
+  SQUARE_ENVIRONMENT: z.enum(["sandbox", "production"]).default("production"),
+  SQUARE_SYNC_ENABLED: booleanEnvSchema,
+  SQUARE_SYNC_CRON: z.string().min(1, "SQUARE_SYNC_CRON is required")
+    .default("*/10 * * * *")
 });
 
 export const env = envSchema.parse(process.env);

--- a/src/config/testEnv.ts
+++ b/src/config/testEnv.ts
@@ -9,3 +9,5 @@ process.env.GOOGLE_CLIENT_SECRET ??= "google-client-secret-test";
 process.env.GOOGLE_REDIRECT_URI ??= "http://localhost:4000/auth/google/callback";
 process.env.SQUARE_ACCESS_TOKEN ??= "square-test-token";
 process.env.SQUARE_ENVIRONMENT ??= "sandbox";
+process.env.SQUARE_SYNC_ENABLED ??= "false";
+process.env.SQUARE_SYNC_CRON ??= "*/10 * * * *";

--- a/src/integrations/square/squareSyncJob.test.ts
+++ b/src/integrations/square/squareSyncJob.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createNodeCronScheduler,
+  createSquareSyncJob,
+  runSquareSyncOnce,
+  type SquareSyncCronScheduler,
+  type SquareSyncLogger,
+  type SquareSyncTask
+} from "@/integrations/square/squareSyncJob";
+
+function createLoggerMock(): SquareSyncLogger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  };
+}
+
+type ManualTaskController = {
+  startCalls: number;
+  stopCalls: number;
+  runScheduled: () => Promise<void>;
+};
+
+function createManualCronScheduler(): {
+  scheduler: SquareSyncCronScheduler;
+  controller: ManualTaskController;
+} {
+  let scheduledRun: (() => Promise<void>) | null = null;
+  const task: SquareSyncTask = {
+    start: vi.fn(),
+    stop: vi.fn()
+  };
+
+  const scheduler: SquareSyncCronScheduler = {
+    schedule: vi.fn().mockImplementation((_cronExpression: string, run: () => Promise<void>) => {
+      scheduledRun = run;
+      return task;
+    })
+  };
+
+  return {
+    scheduler,
+    controller: {
+      get startCalls() {
+        return vi.mocked(task.start).mock.calls.length;
+      },
+      get stopCalls() {
+        return vi.mocked(task.stop).mock.calls.length;
+      },
+      async runScheduled() {
+        if (!scheduledRun) {
+          throw new Error("No scheduled run callback captured.");
+        }
+
+        await scheduledRun();
+      }
+    }
+  };
+}
+
+describe("runSquareSyncOnce", () => {
+  it("fetches catalog objects, syncs them, and logs a summary", async () => {
+    const logger = createLoggerMock();
+    const catalogService = {
+      fetchCatalogItems: vi.fn().mockResolvedValue([{ id: "item-1" }] as never[])
+    };
+    const syncService = {
+      syncCatalogObjects: vi.fn().mockResolvedValue({
+        created: 1,
+        updated: 2,
+        skipped: 3,
+        inventoryRowsSynced: 4
+      })
+    };
+    const now = vi.fn().mockReturnValueOnce(1000).mockReturnValueOnce(1450);
+
+    const result = await runSquareSyncOnce({
+      catalogService,
+      syncService,
+      logger,
+      now
+    });
+
+    expect(catalogService.fetchCatalogItems).toHaveBeenCalledTimes(1);
+    expect(syncService.syncCatalogObjects).toHaveBeenCalledWith([{ id: "item-1" }]);
+    expect(result).toEqual({
+      created: 1,
+      updated: 2,
+      skipped: 3,
+      inventoryRowsSynced: 4
+    });
+
+    expect(logger.info).toHaveBeenCalledWith("[square-sync] run started");
+    expect(logger.info).toHaveBeenLastCalledWith(
+      "[square-sync] run completed",
+      JSON.stringify({
+        catalogObjectsFetched: 1,
+        created: 1,
+        updated: 2,
+        skipped: 3,
+        inventoryRowsSynced: 4,
+        durationMs: 450
+      })
+    );
+  });
+
+  it("uses default logger and clock when optional dependencies are not provided", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const catalogService = {
+      fetchCatalogItems: vi.fn().mockResolvedValue([])
+    };
+    const syncService = {
+      syncCatalogObjects: vi.fn().mockResolvedValue({
+        created: 0,
+        updated: 0,
+        skipped: 0,
+        inventoryRowsSynced: 0
+      })
+    };
+
+    await runSquareSyncOnce({
+      catalogService,
+      syncService
+    });
+
+    expect(infoSpy).toHaveBeenCalled();
+    infoSpy.mockRestore();
+  });
+});
+
+describe("createSquareSyncJob", () => {
+  it("returns a no-op handle when disabled", async () => {
+    const logger = createLoggerMock();
+    const cronScheduler = {
+      schedule: vi.fn()
+    } satisfies SquareSyncCronScheduler;
+
+    const job = createSquareSyncJob(
+      {
+        enabled: false,
+        cronExpression: "*/10 * * * *"
+      },
+      {
+        logger,
+        cronScheduler,
+        catalogService: {
+          fetchCatalogItems: vi.fn().mockResolvedValue([])
+        },
+        syncService: {
+          syncCatalogObjects: vi.fn().mockResolvedValue({
+            created: 0,
+            updated: 0,
+            skipped: 0,
+            inventoryRowsSynced: 0
+          })
+        }
+      }
+    );
+
+    await job.triggerNow();
+    job.stop();
+
+    expect(cronScheduler.schedule).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith("[square-sync] scheduler disabled");
+  });
+
+  it("can use default logger and cron scheduler", () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    const job = createSquareSyncJob(
+      {
+        enabled: true,
+        cronExpression: "* * * * *"
+      },
+      {
+        catalogService: {
+          fetchCatalogItems: vi.fn().mockResolvedValue([])
+        },
+        syncService: {
+          syncCatalogObjects: vi.fn().mockResolvedValue({
+            created: 0,
+            updated: 0,
+            skipped: 0,
+            inventoryRowsSynced: 0
+          })
+        }
+      }
+    );
+
+    job.stop();
+    expect(infoSpy).toHaveBeenCalled();
+    infoSpy.mockRestore();
+  });
+
+  it("starts the scheduled task, runs sync, and stops cleanly", async () => {
+    const logger = createLoggerMock();
+    const { scheduler, controller } = createManualCronScheduler();
+    const catalogService = {
+      fetchCatalogItems: vi.fn().mockResolvedValue([{ id: "item-2" }] as never[])
+    };
+    const syncService = {
+      syncCatalogObjects: vi.fn().mockResolvedValue({
+        created: 1,
+        updated: 0,
+        skipped: 0,
+        inventoryRowsSynced: 1
+      })
+    };
+
+    const job = createSquareSyncJob(
+      {
+        enabled: true,
+        cronExpression: "*/10 * * * *"
+      },
+      {
+        logger,
+        cronScheduler: scheduler,
+        catalogService,
+        syncService
+      }
+    );
+
+    expect(controller.startCalls).toBe(1);
+    await controller.runScheduled();
+    expect(catalogService.fetchCatalogItems).toHaveBeenCalledTimes(1);
+    expect(syncService.syncCatalogObjects).toHaveBeenCalledTimes(1);
+
+    job.stop();
+    expect(controller.stopCalls).toBe(1);
+    expect(logger.info).toHaveBeenCalledWith("[square-sync] scheduler stopped");
+  });
+
+  it("skips overlapping runs and logs failures without throwing", async () => {
+    const logger = createLoggerMock();
+    const { scheduler } = createManualCronScheduler();
+
+    let releaseFetch: () => void = () => {
+      // Placeholder gets replaced inside promise executor.
+    };
+    const pendingFetch = new Promise<unknown[]>((resolve) => {
+      releaseFetch = () => resolve([]);
+    });
+
+    const catalogService = {
+      fetchCatalogItems: vi.fn().mockImplementation(() => pendingFetch)
+    };
+    const syncService = {
+      syncCatalogObjects: vi.fn().mockRejectedValue(new Error("sync boom"))
+    };
+
+    const job = createSquareSyncJob(
+      {
+        enabled: true,
+        cronExpression: "*/10 * * * *"
+      },
+      {
+        logger,
+        cronScheduler: scheduler,
+        catalogService,
+        syncService
+      }
+    );
+
+    const firstRun = job.triggerNow();
+    await job.triggerNow();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[square-sync] skipped run because a previous run is still in progress"
+    );
+
+    releaseFetch();
+    await firstRun;
+
+    expect(logger.error).toHaveBeenCalledWith("[square-sync] run failed", expect.any(Error));
+  });
+});
+
+describe("createNodeCronScheduler", () => {
+  it("creates a schedulable task for a valid cron expression", () => {
+    const scheduler = createNodeCronScheduler();
+
+    const task = scheduler.schedule("* * * * *", async () => { });
+
+    expect(typeof task.start).toBe("function");
+    expect(typeof task.stop).toBe("function");
+    task.start();
+    task.stop();
+  });
+
+  it("throws for an invalid cron expression", () => {
+    const scheduler = createNodeCronScheduler();
+
+    expect(() => scheduler.schedule("not a cron", async () => { })).toThrow(
+      "Invalid SQUARE_SYNC_CRON expression: not a cron"
+    );
+  });
+});

--- a/src/integrations/square/squareSyncJob.ts
+++ b/src/integrations/square/squareSyncJob.ts
@@ -1,0 +1,132 @@
+import cron from "node-cron";
+import type { SquareSyncResult } from "@/integrations/square/squareWineSyncService";
+
+export type SquareSyncLogger = Pick<Console, "info" | "warn" | "error">;
+
+export type CatalogFetchService = {
+  fetchCatalogItems(): Promise<unknown[]>;
+};
+
+export type CatalogSyncService = {
+  syncCatalogObjects(catalogObjects: unknown[]): Promise<SquareSyncResult>;
+};
+
+export type SquareSyncTask = {
+  start(): void;
+  stop(): void;
+};
+
+export type SquareSyncCronScheduler = {
+  schedule(cronExpression: string, run: () => Promise<void>): SquareSyncTask;
+};
+
+export type SquareSyncJobConfig = {
+  enabled: boolean;
+  cronExpression: string;
+};
+
+export type SquareSyncJobDeps = {
+  catalogService: CatalogFetchService;
+  syncService: CatalogSyncService;
+  logger?: SquareSyncLogger;
+  cronScheduler?: SquareSyncCronScheduler;
+  now?: () => number;
+};
+
+export type SquareSyncJobHandle = {
+  stop(): void;
+  triggerNow(): Promise<void>;
+};
+
+const defaultLogger: SquareSyncLogger = console;
+
+export function createNodeCronScheduler(): SquareSyncCronScheduler {
+  return {
+    schedule(cronExpression: string, run: () => Promise<void>) {
+      if (!cron.validate(cronExpression)) {
+        throw new Error(`Invalid SQUARE_SYNC_CRON expression: ${cronExpression}`);
+      }
+
+      const task = cron.schedule(cronExpression, run);
+
+      task.stop();
+      return task;
+    }
+  };
+}
+
+export async function runSquareSyncOnce(
+  deps: Pick<SquareSyncJobDeps, "catalogService" | "syncService" | "logger" | "now">
+): Promise<SquareSyncResult> {
+  const logger = deps.logger ?? defaultLogger;
+  const now = deps.now ?? Date.now;
+
+  logger.info("[square-sync] run started");
+  const startedAt = now();
+
+  const catalogObjects = await deps.catalogService.fetchCatalogItems();
+  const result = await deps.syncService.syncCatalogObjects(catalogObjects);
+
+  logger.info(
+    "[square-sync] run completed",
+    JSON.stringify({
+      catalogObjectsFetched: catalogObjects.length,
+      created: result.created,
+      updated: result.updated,
+      skipped: result.skipped,
+      inventoryRowsSynced: result.inventoryRowsSynced,
+      durationMs: now() - startedAt
+    })
+  );
+
+  return result;
+}
+
+export function createSquareSyncJob(config: SquareSyncJobConfig, deps: SquareSyncJobDeps): SquareSyncJobHandle {
+  const logger = deps.logger ?? defaultLogger;
+  const cronScheduler = deps.cronScheduler ?? createNodeCronScheduler();
+
+  if (!config.enabled) {
+    logger.info("[square-sync] scheduler disabled");
+    return {
+      stop() {
+        // No-op by design when scheduler is disabled.
+      },
+      async triggerNow() {
+        // No-op by design when scheduler is disabled.
+      }
+    };
+  }
+
+  let inProgress = false;
+
+  const runTick = async () => {
+    if (inProgress) {
+      logger.warn("[square-sync] skipped run because a previous run is still in progress");
+      return;
+    }
+
+    inProgress = true;
+    try {
+      await runSquareSyncOnce(deps);
+    } catch (error) {
+      logger.error("[square-sync] run failed", error);
+    } finally {
+      inProgress = false;
+    }
+  };
+
+  const task = cronScheduler.schedule(config.cronExpression, runTick);
+  task.start();
+  logger.info(`[square-sync] scheduler started (cron: ${config.cronExpression})`);
+
+  return {
+    stop() {
+      task.stop();
+      logger.info("[square-sync] scheduler stopped");
+    },
+    async triggerNow() {
+      await runTick();
+    }
+  };
+}

--- a/src/integrations/square/squareSyncScheduler.ts
+++ b/src/integrations/square/squareSyncScheduler.ts
@@ -1,0 +1,57 @@
+import { prisma } from "@/config/prisma";
+import { env } from "@/config/env";
+import { createNodeCronScheduler, createSquareSyncJob, type SquareSyncJobHandle, type SquareSyncLogger } from "@/integrations/square/squareSyncJob";
+import { createSquareCatalogClient } from "@/integrations/square/squareCatalogClient";
+import { SquareCatalogService } from "@/integrations/square/squareCatalogService";
+import { SquareWineSyncService } from "@/integrations/square/squareWineSyncService";
+import { SquareSyncRepository } from "@/repositories/squareSync/SquareSyncRepository";
+import type { CatalogObject } from "square";
+
+export function startSquareSyncScheduler(logger: SquareSyncLogger = console): SquareSyncJobHandle {
+  if (!env.SQUARE_SYNC_ENABLED) {
+    logger.info("[square-sync] scheduler not enabled by configuration");
+    return createSquareSyncJob(
+      {
+        enabled: false,
+        cronExpression: env.SQUARE_SYNC_CRON
+      },
+      {
+        catalogService: {
+          fetchCatalogItems: async () => []
+        },
+        syncService: {
+          syncCatalogObjects: async () => ({
+            created: 0,
+            updated: 0,
+            skipped: 0,
+            inventoryRowsSynced: 0
+          })
+        },
+        logger
+      }
+    );
+  }
+
+  const catalogClient = createSquareCatalogClient();
+  const catalogService = new SquareCatalogService(catalogClient);
+  const squareSyncRepository = new SquareSyncRepository(prisma);
+  const syncService = new SquareWineSyncService(squareSyncRepository);
+
+  return createSquareSyncJob(
+    {
+      enabled: true,
+      cronExpression: env.SQUARE_SYNC_CRON
+    },
+    {
+      catalogService: {
+        fetchCatalogItems: () => catalogService.fetchCatalogItems()
+      },
+      syncService: {
+        syncCatalogObjects: (catalogObjects: unknown[]) =>
+          syncService.syncCatalogObjects(catalogObjects as CatalogObject[])
+      },
+      cronScheduler: createNodeCronScheduler(),
+      logger
+    }
+  );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,20 @@
 import app from "./app";
 import { env } from "./config/env";
+import { startSquareSyncScheduler } from "./integrations/square/squareSyncScheduler";
 
-app.listen(env.PORT, () => {
+const squareSyncScheduler = startSquareSyncScheduler();
+
+const server = app.listen(env.PORT, () => {
   console.log(`Pourhouse Wine Co. API listening on port ${env.PORT}`);
 });
+
+const shutdown = (signal: string) => {
+  console.log(`Received ${signal}, shutting down.`);
+  squareSyncScheduler.stop();
+  server.close(() => {
+    process.exit(0);
+  });
+};
+
+process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));


### PR DESCRIPTION
## Issues

Closes #5

## Summary

Implements a scheduled Square-to-database sync job with cron-based intervals, startup/shutdown lifecycle handling, idempotent run protection, structured logging, and full unit coverage.

## Changes

- Added scheduler core in `src/integrations/square/squareSyncJob.ts` with:
	- cron scheduling support using `node-cron`
	- overlap prevention (skip if prior run still in progress)
	- run start/completion/failure logging
	- one-shot runner utility for reuse
- Added runtime wiring in `src/integrations/square/squareSyncScheduler.ts` to connect existing `SquareCatalogService` and `SquareWineSyncService`.
- Wired scheduler lifecycle in `src/server.ts` (start on boot, stop on `SIGINT`/`SIGTERM`).
- Added environment configuration:
	- `SQUARE_SYNC_ENABLED`
	- `SQUARE_SYNC_CRON`
- Updated env parsing defaults in `src/config/env.ts` and test defaults in `src/config/testEnv.ts`.
- Added focused tests in `src/integrations/square/squareSyncJob.test.ts` for enable/disable behavior, overlap handling, error logging, and cron validation.
- Updated `.env.example`, `docs/environment.md`, and `README.md` to document scheduler setup and behavior.
- Added `node-cron` dependency in `package.json` and `package-lock.json`.

## Verification

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npx prisma validate`
- [x] Relevant endpoint checks completed

## Checklist

- [x] No secrets were added
- [x] README and docs updated (if needed)
- [x] Backward compatibility considered
