### PR TITLE
docs: reorganize documentation and slim README

### DIFF
--- a/.github/.tmp_pr_body_docs_reorg.md
+++ b/.github/.tmp_pr_body_docs_reorg.md
@@ -1,0 +1,31 @@
+## Issues
+
+Closes #74
+
+## Summary
+
+Restructures project documentation so `README.md` stays concise and navigational, while detailed reference material lives in dedicated docs pages with a clear index.
+
+## Changes
+
+- Slimmed `README.md` by removing long inline API/rules reference sections.
+- Added a centralized documentation index at `docs/index.md`.
+- Added `docs/api-reference.md` for endpoint details, params, and examples.
+- Added `docs/domain-rules.md` for business logic and behavior constraints.
+- Updated `docs/database.md` model list for current schema completeness.
+- Added status clarification to `docs/square-integration-model.md` to distinguish reference/proposed content from operational runbooks.
+- Updated README links to route readers to the right canonical docs pages.
+
+## Verification
+
+- [x] `npm run build`
+- [x] `npm run test`
+- [x] `npm run test:coverage`
+- [x] `npx prisma validate`
+- [x] Relevant endpoint checks completed
+
+## Checklist
+
+- [x] No secrets were added
+- [x] README and docs updated (if needed)
+- [x] Backward compatibility considered

--- a/README.md
+++ b/README.md
@@ -31,56 +31,14 @@ prisma/
   seed.ts
 ```
 
-## Prerequisites
+## Development Setup
 
-- Node.js 20+
-- PostgreSQL running locally or remotely
-
-## Setup
-
-1. Install dependencies:
-
-```bash
-npm install
-```
-
-2. Create environment file:
-
-```bash
-cp .env.example .env
-```
-
-3. Update `.env` values for your environment.
-
-4. Run database migrations:
-
-```bash
-npx prisma migrate dev
-```
-
-For first deployment (and all non-development environments), use deploy-mode migrations:
-
-```bash
-npx prisma migrate deploy
-```
-
-5. Seed sample data:
-
-```bash
-npm run prisma:seed
-```
-
-6. Start dev server:
-
-```bash
-npm run dev
-```
-
-API runs at `http://localhost:4000` by default.
+For prerequisites, local environment setup, database migration flow, and sample-data seeding, see [Development Setup](docs/development-setup.md).
 
 ## Documentation Index
 
 - [Documentation Home](docs/index.md)
+- [Development Setup](docs/development-setup.md)
 - [Architecture](docs/architecture.md)
 - [Environment Configuration](docs/environment.md)
 - [Database](docs/database.md)
@@ -145,24 +103,6 @@ The API supports a background scheduler that fetches Square catalog data and syn
 - Each run logs start, completion summary (created/updated/skipped/inventoryRowsSynced), and failures.
 
 For detailed integration usage, see [Squarespace Integration Runbook](docs/squarespace-integration.md).
-
-## Sample Data Seeding
-
-Use the combined command when you want realistic demo data in both Square sandbox and your local database:
-
-```bash
-npm run seed:sample:data
-```
-
-This runs three steps in order:
-
-1. `npm run prisma:seed`
-2. `npm run square:seed:sandbox`
-3. `npm run square:sync:wines`
-
-When `sample_data/*.xlsx` exists, `npm run square:seed:sandbox` reads the newest workbook and seeds catalog items from the `Items` sheet. If no workbook is found, it falls back to bundled sample fixtures.
-
-You can also run individual steps as needed.
 
 ## API and Rules
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,6 @@ For prerequisites, local environment setup, database migration flow, and sample-
 - [Squarespace Integration Runbook](docs/squarespace-integration.md)
 - [Square Data Structure and Integration Model](docs/square-integration-model.md)
 
-## Scripts and Environment
-
-For the full scripts reference and environment variable setup, see [Development Setup](docs/development-setup.md) and [Environment Configuration](docs/environment.md).
-
 ## Scheduled Square Sync
 
 The API supports a background scheduler that fetches Square catalog data and syncs it into local wines/inventory.

--- a/README.md
+++ b/README.md
@@ -47,52 +47,9 @@ For prerequisites, local environment setup, database migration flow, and sample-
 - [Squarespace Integration Runbook](docs/squarespace-integration.md)
 - [Square Data Structure and Integration Model](docs/square-integration-model.md)
 
-## Scripts
+## Scripts and Environment
 
-- `npm run dev` - run API in development with auto-reload
-- `npm run dev:full` - start Postgres and run the API in development
-- `npm run build` - compile TypeScript to `dist`
-- `npm run lint` - run ESLint across the project
-- `npm run format` - format the project with Prettier
-- `npm run test` - run the Vitest suite once
-- `npm run test:watch` - run Vitest in watch mode
-- `npm run test:coverage` - run Vitest with 100% coverage thresholds enabled
-- `npm run start` - run compiled server
-- `npm run square:fetch` - fetch catalog data from Square
-- `npm run square:seed:sandbox` - seed sample catalog items into Square sandbox (safe-guarded to sandbox env)
-- `npm run square:sync:wines` - sync Square catalog wines into the database
-- `npm run seed:sample:data` - seed local DB, seed Square sandbox catalog, then sync Square data into local wines
-- `npm run admin:grant -- <email>` - grant admin role to an existing user
-- `npm run admin:revoke -- <email>` - revoke admin role from a user
-- `npm run prisma:generate` - generate Prisma client
-- `npm run prisma:migrate` - run migrations in development
-- `npx prisma migrate deploy` - apply committed migrations in CI/staging/production
-- `npm run prisma:seed` - seed sample data
-- `npm run db:up` - start the local Postgres container
-- `npm run db:down` - stop the local Postgres container
-- `npm run db:status` - inspect the local Postgres container
-- `npm run db:logs` - tail Postgres container logs
-- `npm run db:reset` - destroy the local Postgres data volume
-- `npm run db:setup` - start Postgres, run migrations, and seed data
-
-## Environment Variables
-
-Use `.env.example` as a template:
-
-- `NODE_ENV`
-- `PORT`
-- `DATABASE_URL`
-- `JWT_SECRET`
-- `JWT_EXPIRES_IN`
-- `GOOGLE_CLIENT_ID`
-- `GOOGLE_CLIENT_SECRET`
-- `GOOGLE_REDIRECT_URI`
-- `SQUARE_ACCESS_TOKEN`
-- `SQUARE_ENVIRONMENT`
-- `SQUARE_SYNC_ENABLED`
-- `SQUARE_SYNC_CRON`
-
-For sample-data seeding workflows, set `SQUARE_ENVIRONMENT=sandbox` and use a Square sandbox access token.
+For the full scripts reference and environment variable setup, see [Development Setup](docs/development-setup.md) and [Environment Configuration](docs/environment.md).
 
 ## Scheduled Square Sync
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ npm run dev
 
 API runs at `http://localhost:4000` by default.
 
+## Documentation Index
+
+- [Documentation Home](docs/index.md)
+- [Architecture](docs/architecture.md)
+- [Environment Configuration](docs/environment.md)
+- [Database](docs/database.md)
+- [API Reference](docs/api-reference.md)
+- [Domain Rules](docs/domain-rules.md)
+- [Squarespace Integration Runbook](docs/squarespace-integration.md)
+- [Square Data Structure and Integration Model](docs/square-integration-model.md)
+
 ## Scripts
 
 - `npm run dev` - run API in development with auto-reload
@@ -133,7 +144,7 @@ The API supports a background scheduler that fetches Square catalog data and syn
 - Set `SQUARE_SYNC_CRON` to control the interval (default: `*/10 * * * *`, every 10 minutes).
 - Each run logs start, completion summary (created/updated/skipped/inventoryRowsSynced), and failures.
 
-For Squarespace embed setup, security header guidance, and troubleshooting, see `docs/squarespace-integration.md`.
+For detailed integration usage, see [Squarespace Integration Runbook](docs/squarespace-integration.md).
 
 ## Sample Data Seeding
 
@@ -153,184 +164,7 @@ When `sample_data/*.xlsx` exists, `npm run square:seed:sandbox` reads the newest
 
 You can also run individual steps as needed.
 
-## API Endpoints
+## API and Rules
 
-### Auth
-
-- `GET /api/auth/google/start` - redirects browser to Google OAuth consent
-- `GET /api/auth/google/callback` - exchanges Google code and redirects back with app JWT
-- `POST /api/auth/google`
-
-### Wines
-
-- `GET /api/wines` - returns a paginated wine list with optional filters and public availability flags
-- `GET /api/wines/grouped` - returns wines grouped by inferred type, then by region
-- `GET /api/wines/:slug`
-- `GET /api/wines/qr/:code` - resolves a QR code token (slug or Square item id) and redirects to `/wines/:slug`
-- `POST /api/wines` - creates a wine and generates its slug from `name` + `vintage`
-- `GET /api/wines/search?q=term`
-- `GET /api/wines/:id/ratings`
-
-### Admin Wines
-
-Admin routes require `Authorization: Bearer <app-jwt>`, and the authenticated user must have `role=ADMIN` in the database.
-The admin UI at `/admin/wines` now uses Google sign-in and stores the app JWT in browser local storage.
-
-- `GET /api/admin/wines`
-- `POST /api/admin/wines`
-- `PUT /api/admin/wines/:id`
-- `DELETE /api/admin/wines/:id`
-
-Supported `GET /api/wines` query params:
-
-- `page` - 1-based page number, defaults to `1`
-- `pageSize` - page size between `1` and `100`, defaults to `20`
-- `sort` - `createdAt`, `name`, `priceGlass`, or `priceBottle`
-- `order` - `asc` or `desc`
-- `country` - exact country filter, case-insensitive
-- `regionId` - filter by region id
-- `wineryId` - filter by winery id
-- `featuredOnly` - `true` or `false`
-- `hasGlass` - `true` or `false`
-- `hasBottle` - `true` or `false`
-
-Example `GET /api/wines` response:
-
-```json
-{
-  "items": [
-    {
-      "id": "wine-id",
-      "slug": "cabernet-2020",
-      "name": "Cabernet",
-      "vintage": 2020,
-      "country": "US",
-      "description": "Bold",
-      "imageUrl": "https://example.com/wine.png",
-      "winery": {
-        "id": "winery-1",
-        "name": "Alpha Winery"
-      },
-      "region": {
-        "id": "region-1",
-        "name": "Napa Valley"
-      },
-      "availableByBottle": true,
-      "availableByGlass": true,
-      "availableForFlight": false
-    }
-  ],
-  "page": 1,
-  "pageSize": 20,
-  "total": 1,
-  "totalPages": 1
-}
-```
-
-Example filtered request:
-
-```text
-GET /api/wines?page=1&pageSize=10&sort=priceGlass&order=asc&country=US&featuredOnly=true
-```
-
-Example `GET /api/wines/grouped` response:
-
-```json
-{
-  "groups": [
-    {
-      "type": "red",
-      "regions": [
-        {
-          "id": "region-1",
-          "name": "Napa Valley",
-          "wines": [
-            {
-              "id": "wine-id",
-              "slug": "cabernet-2020",
-              "name": "Cabernet",
-              "vintage": 2020,
-              "country": "US",
-              "description": "Bold",
-              "imageUrl": "https://example.com/wine.png",
-              "winery": {
-                "id": "winery-1",
-                "name": "Alpha Winery"
-              },
-              "region": {
-                "id": "region-1",
-                "name": "Napa Valley"
-              },
-              "availableByBottle": true,
-              "availableByGlass": true,
-              "availableForFlight": false
-            }
-          ]
-        }
-      ]
-    }
-  ],
-  "totalWines": 1
-}
-```
-
-## Embeddable Wine List
-
-The embeddable wine list is available at `GET /embed/wine-list` and loads grouped wines from `GET /api/wines/grouped`.
-
-For complete Squarespace embed instructions (iframe and loader options), security header guidance, scheduler expectations, and troubleshooting, see `docs/squarespace-integration.md`.
-
-Example `POST /api/wines` request body:
-
-```json
-{
-  "name": "Opus One",
-  "vintage": 2019,
-  "wineryId": "winery-id",
-  "regionId": "region-id",
-  "country": "US",
-  "grapeVarieties": ["Cabernet Sauvignon", "Merlot"],
-  "alcoholPercent": 14.5,
-  "description": "Structured and age-worthy.",
-  "imageUrl": "https://example.com/opus-one.png"
-}
-```
-
-Generated slugs are based on `name` + `vintage` and receive a numeric suffix when needed to stay unique, for example `opus-one-2019` or `opus-one-2019-2`.
-
-### Inventory
-
-- `GET /api/inventory`
-- `GET /api/inventory/:id`
-- `POST /api/inventory`
-- `PATCH /api/inventory/:id`
-
-### Ratings
-
-- `POST /api/ratings` (requires JWT)
-
-### Frontend Page
-
-- `GET /wines/:slug` - mobile-friendly wine detail page that loads data from `GET /api/wines/:slug` and displays name, description, and pricing
-
-## Business Rules Implemented
-
-- Duplicate wines prevented by composite unique constraint on `(name, wineryId, vintage)`.
-- Ratings constrained to 1-5 by validation and service guard.
-- Only authenticated users can create ratings.
-- Inventory references wines by foreign key (`wineId`) and does not duplicate wine records.
-- Public wine list responses include only wines with available inventory.
-- Public wine list pricing is summarized from available inventory rows using the lowest available glass and bottle prices.
-- Public wine list filtering is applied in the repository layer; price sorting and pagination are applied in the service layer.
-
-## Seed Data
-
-Seed includes:
-
-- Regions (France, Bordeaux, Napa Valley)
-- Wineries
-- Wines
-- Inventory records
-- Default user email (`admin@pourhousewineco.com`) for Google identity linking and role assignment
-
-Grant or revoke admin access with `npm run admin:grant -- <email>` and `npm run admin:revoke -- <email>`.
+- For endpoints, request/response examples, and query parameters, see [API Reference](docs/api-reference.md).
+- For business constraints and behavior guarantees, see [Domain Rules](docs/domain-rules.md).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,159 @@
+# API Reference
+
+All API routes are mounted under `/api` unless otherwise noted.
+
+## Auth
+
+- `GET /api/auth/google/start` - Redirects browser to Google OAuth consent.
+- `GET /api/auth/google/callback` - Exchanges Google code and redirects back with app JWT.
+- `POST /api/auth/google` - Authenticates using a Google ID token payload.
+
+## Wines
+
+- `GET /api/wines` - Returns paginated wines with filters.
+- `GET /api/wines/grouped` - Returns wines grouped by inferred type, then by region.
+- `GET /api/wines/:slug` - Returns a single wine by slug.
+- `GET /api/wines/qr/:code` - Resolves QR token (slug or Square item id) and redirects to `/wines/:slug`.
+- `GET /api/wines/search?q=term` - Searches wines.
+- `POST /api/wines` - Creates a wine.
+- `GET /api/wines/:id/ratings` - Lists ratings for a wine.
+
+### Wines Query Params
+
+Supported `GET /api/wines` query params:
+
+- `page` - 1-based page number, default `1`
+- `pageSize` - 1 to 100, default `20`
+- `sort` - `createdAt`, `name`, `priceGlass`, or `priceBottle`
+- `order` - `asc` or `desc`
+- `country` - exact country filter, case-insensitive
+- `regionId` - filter by region id
+- `wineryId` - filter by winery id
+- `featuredOnly` - `true` or `false`
+- `hasGlass` - `true` or `false`
+- `hasBottle` - `true` or `false`
+
+Example filtered request:
+
+```text
+GET /api/wines?page=1&pageSize=10&sort=priceGlass&order=asc&country=US&featuredOnly=true
+```
+
+Example `GET /api/wines` response:
+
+```json
+{
+  "items": [
+    {
+      "id": "wine-id",
+      "slug": "cabernet-2020",
+      "name": "Cabernet",
+      "vintage": 2020,
+      "country": "US",
+      "description": "Bold",
+      "imageUrl": "https://example.com/wine.png",
+      "winery": {
+        "id": "winery-1",
+        "name": "Alpha Winery"
+      },
+      "region": {
+        "id": "region-1",
+        "name": "Napa Valley"
+      },
+      "availableByBottle": true,
+      "availableByGlass": true,
+      "availableForFlight": false
+    }
+  ],
+  "page": 1,
+  "pageSize": 20,
+  "total": 1,
+  "totalPages": 1
+}
+```
+
+Example `GET /api/wines/grouped` response:
+
+```json
+{
+  "groups": [
+    {
+      "type": "red",
+      "regions": [
+        {
+          "id": "region-1",
+          "name": "Napa Valley",
+          "wines": [
+            {
+              "id": "wine-id",
+              "slug": "cabernet-2020",
+              "name": "Cabernet",
+              "vintage": 2020,
+              "country": "US",
+              "description": "Bold",
+              "imageUrl": "https://example.com/wine.png",
+              "winery": {
+                "id": "winery-1",
+                "name": "Alpha Winery"
+              },
+              "region": {
+                "id": "region-1",
+                "name": "Napa Valley"
+              },
+              "availableByBottle": true,
+              "availableByGlass": true,
+              "availableForFlight": false
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "totalWines": 1
+}
+```
+
+Example `POST /api/wines` body:
+
+```json
+{
+  "name": "Opus One",
+  "vintage": 2019,
+  "wineryId": "winery-id",
+  "regionId": "region-id",
+  "country": "US",
+  "grapeVarieties": ["Cabernet Sauvignon", "Merlot"],
+  "alcoholPercent": 14.5,
+  "description": "Structured and age-worthy.",
+  "imageUrl": "https://example.com/opus-one.png"
+}
+```
+
+Generated slugs are based on `name` and `vintage`, with a numeric suffix when needed.
+
+## Admin Wines
+
+Requires `Authorization: Bearer <app-jwt>` and `role=ADMIN`.
+
+- `GET /api/admin/wines`
+- `POST /api/admin/wines`
+- `PUT /api/admin/wines/:id`
+- `DELETE /api/admin/wines/:id`
+
+## Inventory
+
+- `GET /api/inventory`
+- `GET /api/inventory/:id`
+- `POST /api/inventory`
+- `PATCH /api/inventory/:id`
+
+## Ratings
+
+- `POST /api/ratings` (requires JWT)
+
+## Frontend Routes (non-API)
+
+- `GET /wines/:slug` - Wine detail page.
+- `GET /embed/wine-list` - Embeddable wine list shell.
+
+For embed setup, security, and troubleshooting, see [Squarespace Integration Runbook](squarespace-integration.md).

--- a/docs/database.md
+++ b/docs/database.md
@@ -49,11 +49,18 @@ Models:
 | Model | Description |
 |---|---|
 | `Wine` | Core wine record; unique on `(name, wineryId, vintage)`. Has a unique `slug` for URL-safe identification and an optional unique `squareItemId` for Square POS integration. |
+| `WineVariation` | Price/size variation records for a wine, including optional `squareVariationId` mapping. |
+| `WineVariationServingMode` | Serving-mode metadata (for example `GLASS_5OZ`, `BOTTLE_750ML`) associated with a variation. |
 | `Winery` | Wine producer; belongs to a `Region` |
 | `Region` | Hierarchical geographic region (self-referencing) |
+| `Flight` | Curated tasting flight definition. |
+| `FlightWine` | Join model between flights and wines with pour position ordering. |
 | `Inventory` | Per-wine stock, pricing, and availability |
 | `User` | Application user account |
 | `Rating` | User rating (1–5) with optional notes for a wine |
+| `SquareCatalogItem` | Staging record of synced Square item payloads and sync metadata. |
+| `SquareCatalogVariation` | Staging record of synced Square variation payloads and sync metadata. |
+| `SquareServingModeOverride` | Manual override mapping from Square variation id to serving mode. |
 
 ### Scripts
 

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -1,0 +1,76 @@
+# Development Setup
+
+This guide covers local development setup for the Pourhouse backend.
+
+## Prerequisites
+
+- Node.js 20+
+- PostgreSQL running locally or remotely
+
+For local containerized PostgreSQL, use `npm run db:up` (see [database.md](database.md)).
+
+## Setup Steps
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Create environment file:
+
+```bash
+cp .env.example .env
+```
+
+3. Update `.env` values for your environment.
+
+4. Run development migrations:
+
+```bash
+npx prisma migrate dev
+```
+
+For first deployment (and all non-development environments), use deploy-mode migrations:
+
+```bash
+npx prisma migrate deploy
+```
+
+5. Seed sample data:
+
+```bash
+npm run prisma:seed
+```
+
+6. Start the development server:
+
+```bash
+npm run dev
+```
+
+API runs at `http://localhost:4000` by default.
+
+## Sample Data Workflow
+
+For realistic local demo data synced with Square sandbox:
+
+```bash
+npm run seed:sample:data
+```
+
+This runs in order:
+
+1. `npm run prisma:seed`
+2. `npm run square:seed:sandbox`
+3. `npm run square:sync:wines`
+
+When `sample_data/*.xlsx` exists, `npm run square:seed:sandbox` reads the newest workbook and seeds catalog items from the `Items` sheet. If no workbook is found, it falls back to bundled sample fixtures.
+
+## Useful Commands
+
+- `npm run dev:full` - start Postgres and run API in development
+- `npm run build` - compile TypeScript to `dist`
+- `npm run test` - run tests once
+- `npm run test:coverage` - run tests with coverage thresholds
+- `npm run db:status` - inspect local Postgres container status

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -74,3 +74,52 @@ When `sample_data/*.xlsx` exists, `npm run square:seed:sandbox` reads the newest
 - `npm run test` - run tests once
 - `npm run test:coverage` - run tests with coverage thresholds
 - `npm run db:status` - inspect local Postgres container status
+
+## Scripts Reference
+
+- `npm run dev` - run API in development with auto-reload
+- `npm run dev:full` - start Postgres and run API in development
+- `npm run build` - compile TypeScript to `dist`
+- `npm run lint` - run ESLint across the project
+- `npm run format` - format the project with Prettier
+- `npm run test` - run the Vitest suite once
+- `npm run test:watch` - run Vitest in watch mode
+- `npm run test:coverage` - run Vitest with 100% coverage thresholds enabled
+- `npm run start` - run compiled server
+- `npm run square:fetch` - fetch catalog data from Square
+- `npm run square:seed:sandbox` - seed sample catalog items into Square sandbox (safe-guarded to sandbox env)
+- `npm run square:sync:wines` - sync Square catalog wines into the database
+- `npm run seed:sample:data` - seed local DB, seed Square sandbox catalog, then sync Square data into local wines
+- `npm run admin:grant -- <email>` - grant admin role to an existing user
+- `npm run admin:revoke -- <email>` - revoke admin role from a user
+- `npm run prisma:generate` - generate Prisma client
+- `npm run prisma:migrate` - run migrations in development
+- `npx prisma migrate deploy` - apply committed migrations in CI/staging/production
+- `npm run prisma:seed` - seed sample data
+- `npm run db:up` - start the local Postgres container
+- `npm run db:down` - stop the local Postgres container
+- `npm run db:status` - inspect the local Postgres container
+- `npm run db:logs` - tail Postgres container logs
+- `npm run db:reset` - destroy the local Postgres data volume
+- `npm run db:setup` - start Postgres, run migrations, and seed data
+
+## Environment Variables
+
+Use `.env.example` as a template:
+
+- `NODE_ENV`
+- `PORT`
+- `DATABASE_URL`
+- `JWT_SECRET`
+- `JWT_EXPIRES_IN`
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `GOOGLE_REDIRECT_URI`
+- `SQUARE_ACCESS_TOKEN`
+- `SQUARE_ENVIRONMENT`
+- `SQUARE_SYNC_ENABLED`
+- `SQUARE_SYNC_CRON`
+
+For sample-data seeding workflows, set `SQUARE_ENVIRONMENT=sandbox` and use a Square sandbox access token.
+
+For variable validation rules and defaults, see [Environment Configuration](environment.md).

--- a/docs/domain-rules.md
+++ b/docs/domain-rules.md
@@ -1,0 +1,21 @@
+# Domain Rules
+
+This document captures the key business rules currently implemented in the application.
+
+## Wine and Inventory Rules
+
+- Duplicate wines are prevented by a composite unique constraint on `(name, wineryId, vintage)`.
+- Inventory references wines by foreign key (`wineId`) and does not duplicate wine records.
+- Public wine list responses include only wines with available inventory.
+- Public wine list pricing is summarized from available inventory rows using the lowest available glass and bottle prices.
+- Public wine list filtering is applied in the repository layer; price sorting and pagination are applied in the service layer.
+
+## Ratings Rules
+
+- Ratings are constrained to 1 through 5 by validation and service guards.
+- Only authenticated users can create ratings.
+
+## Admin and Access Rules
+
+- Admin wine routes require bearer auth and a user with `role=ADMIN`.
+- Public endpoints remain available without JWT except where explicitly protected.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,10 +4,11 @@ Use this page as the entry point for project documentation.
 
 ## Start Here
 
-1. [Architecture](architecture.md)
-2. [Environment Configuration](environment.md)
-3. [Database](database.md)
-4. [API Reference](api-reference.md)
+1. [Development Setup](development-setup.md)
+2. [Architecture](architecture.md)
+3. [Environment Configuration](environment.md)
+4. [Database](database.md)
+5. [API Reference](api-reference.md)
 
 ## Integration and Operations
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,26 @@
+# Documentation Index
+
+Use this page as the entry point for project documentation.
+
+## Start Here
+
+1. [Architecture](architecture.md)
+2. [Environment Configuration](environment.md)
+3. [Database](database.md)
+4. [API Reference](api-reference.md)
+
+## Integration and Operations
+
+- [Squarespace Integration Runbook](squarespace-integration.md)
+- [Square Data Structure and Integration Model](square-integration-model.md)
+- [Domain Rules](domain-rules.md)
+
+## Schema Snapshots and Planning Docs
+
+- [Current Schema Snapshot](schema-current.md)
+- [Target Schema (Issue 14)](schema-target-issue-14.md)
+
+## Notes
+
+- `schema-current.md` and `schema-target-issue-14.md` are design/reference artifacts, not executable migration plans.
+- For day-to-day setup and runtime behavior, prefer the Start Here and Integration sections above.

--- a/docs/square-integration-model.md
+++ b/docs/square-integration-model.md
@@ -1,5 +1,11 @@
 # Square Data Structure & Integration Model
 
+## Document Status
+
+- This document combines historical context and design notes from Issue #14.
+- Parts labeled as "proposed" are architectural reference, not guaranteed current behavior.
+- For operational embed setup and production configuration, use `docs/squarespace-integration.md`.
+
 ## Overview
 
 Square provides catalog data via the Catalog API. This document outlines:


### PR DESCRIPTION
## Issues

Closes #74

## Summary

Restructures project documentation so `README.md` stays concise and navigational, while detailed reference material lives in dedicated docs pages with a clear index.

## Changes

- Slimmed `README.md` by removing long inline API/rules reference sections.
- Added a centralized documentation index at `docs/index.md`.
- Added `docs/api-reference.md` for endpoint details, params, and examples.
- Added `docs/domain-rules.md` for business logic and behavior constraints.
- Updated `docs/database.md` model list for current schema completeness.
- Added status clarification to `docs/square-integration-model.md` to distinguish reference/proposed content from operational runbooks.
- Updated README links to route readers to the right canonical docs pages.

## Verification

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npx prisma validate`
- [x] Relevant endpoint checks completed

## Checklist

- [x] No secrets were added
- [x] README and docs updated (if needed)
- [x] Backward compatibility considered
