### PR TITLE
refactor: standardize local port defaults to 8080

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
 NODE_ENV=development
-PORT=4000
+PORT=8080
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/pourhouse?schema=public"
 JWT_SECRET="replace-with-a-strong-secret"
 JWT_EXPIRES_IN="7d"
 GOOGLE_CLIENT_ID="replace-with-google-client-id"
 GOOGLE_CLIENT_SECRET="replace-with-google-client-secret"
-GOOGLE_REDIRECT_URI="http://localhost:4000/auth/google/callback"
+GOOGLE_REDIRECT_URI="http://localhost:8080/auth/google/callback"
 
 # Square API
 SQUARE_ACCESS_TOKEN="replace-with-square-access-token"

--- a/.github/.tmp_pr_body_refactor_ports.md
+++ b/.github/.tmp_pr_body_refactor_ports.md
@@ -1,0 +1,28 @@
+## Issues
+
+Closes #
+
+## Summary
+
+Standardizes local runtime defaults to port 8080 and aligns related docs/tests so local startup and OAuth callback expectations remain consistent.
+
+## Changes
+
+- Updated default/local port references from 4000 to 8080 in configuration and examples.
+- Updated Google redirect URI defaults to use localhost:8080.
+- Updated test env defaults and auth-related test expectations to match 8080.
+- Updated development and environment documentation defaults to 8080.
+
+## Verification
+
+- [x] `npm run build`
+- [x] `npm run test`
+- [x] `npm run test:coverage`
+- [x] `npx prisma validate`
+- [x] Relevant endpoint checks completed
+
+## Checklist
+
+- [x] No secrets were added
+- [x] README and docs updated (if needed)
+- [x] Backward compatibility considered

--- a/docs/development-setup.md
+++ b/docs/development-setup.md
@@ -49,7 +49,7 @@ npm run prisma:seed
 npm run dev
 ```
 
-API runs at `http://localhost:4000` by default.
+API runs at `http://localhost:8080` by default.
 
 ## Sample Data Workflow
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -21,7 +21,7 @@ cp .env.example .env
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `NODE_ENV` | No | `development` | Runtime environment. Accepted values: `development`, `test`, `production`. |
-| `PORT` | No | `4000` | Port the HTTP server listens on. |
+| `PORT` | No | `8080` | Port the HTTP server listens on. |
 | `DATABASE_URL` | Yes | — | PostgreSQL connection string. Example: `postgresql://postgres:postgres@localhost:5432/pourhouse?schema=public` |
 | `JWT_SECRET` | Yes | — | Secret used to sign and verify JWTs. Must be at least 16 characters. |
 | `JWT_EXPIRES_IN` | No | `7d` | JWT expiry duration in [vercel/ms](https://github.com/vercel/ms) format (e.g. `7d`, `1h`, `30m`). |

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -10,7 +10,7 @@ const booleanEnvSchema = z
 
 const envSchema = z.object({
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),
-  PORT: z.coerce.number().int().positive().default(4000),
+  PORT: z.coerce.number().int().positive().default(8080),
   DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
   JWT_SECRET: z.string().min(16, "JWT_SECRET must be at least 16 characters"),
   JWT_EXPIRES_IN: z.string().default("7d"),

--- a/src/config/testEnv.ts
+++ b/src/config/testEnv.ts
@@ -1,12 +1,12 @@
 // Provide safe defaults for tests that import env-dependent modules at load time.
 process.env.NODE_ENV ??= "test";
-process.env.PORT ??= "4000";
+process.env.PORT ??= "8080";
 process.env.DATABASE_URL ??= "postgresql://test:test@localhost:5432/pourhouse_test?schema=public";
 process.env.JWT_SECRET ??= "test-secret-123456";
 process.env.JWT_EXPIRES_IN ??= "7d";
 process.env.GOOGLE_CLIENT_ID ??= "google-client-id-test";
 process.env.GOOGLE_CLIENT_SECRET ??= "google-client-secret-test";
-process.env.GOOGLE_REDIRECT_URI ??= "http://localhost:4000/auth/google/callback";
+process.env.GOOGLE_REDIRECT_URI ??= "http://localhost:8080/auth/google/callback";
 process.env.SQUARE_ACCESS_TOKEN ??= "square-test-token";
 process.env.SQUARE_ENVIRONMENT ??= "sandbox";
 process.env.SQUARE_SYNC_ENABLED ??= "false";

--- a/src/controllers/authController.test.ts
+++ b/src/controllers/authController.test.ts
@@ -6,7 +6,7 @@ import type { AuthService } from "@/services/authService";
 vi.mock("@/config/env", () => ({
   env: {
     GOOGLE_CLIENT_ID: "google-client-id-test",
-    GOOGLE_REDIRECT_URI: "http://localhost:4000/api/auth/google/callback"
+    GOOGLE_REDIRECT_URI: "http://localhost:8080/api/auth/google/callback"
   }
 }));
 
@@ -39,7 +39,7 @@ describe("AuthController", () => {
     expect(statusCode).toBe(302);
     expect(redirectUrl).toContain("https://accounts.google.com/o/oauth2/v2/auth");
     expect(redirectUrl).toContain("client_id=google-client-id-test");
-    expect(redirectUrl).toContain("redirect_uri=http%3A%2F%2Flocalhost%3A4000%2Fapi%2Fauth%2Fgoogle%2Fcallback");
+    expect(redirectUrl).toContain("redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fapi%2Fauth%2Fgoogle%2Fcallback");
     expect(redirectUrl).toContain("scope=openid+email+profile");
     expect(redirectUrl).toContain("state=L2FkbWluL3dpbmVz");
   });
@@ -102,7 +102,7 @@ describe("AuthController", () => {
 
     expect(authService.authenticateWithGoogle).toHaveBeenCalledWith({
       authorizationCode: "auth-code",
-      redirectUri: "http://localhost:4000/api/auth/google/callback"
+      redirectUri: "http://localhost:8080/api/auth/google/callback"
     });
     expect(res.redirect).toHaveBeenCalledWith(302, "/admin/wines#token=token-value");
   });

--- a/src/services/authService.test.ts
+++ b/src/services/authService.test.ts
@@ -54,7 +54,7 @@ describe("AuthService", () => {
 
     expect(googleAuthClient.exchangeAuthorizationCode).toHaveBeenCalledWith({
       authorizationCode: "auth-code",
-      redirectUri: "http://localhost:4000/auth/google/callback"
+      redirectUri: "http://localhost:8080/auth/google/callback"
     });
     expect(result.user).toEqual({
       id: "user-1",
@@ -103,12 +103,12 @@ describe("AuthService", () => {
 
     const result = await service.authenticateWithGoogle({
       authorizationCode: "auth-code",
-      redirectUri: "http://localhost:4000/custom-google-callback"
+      redirectUri: "http://localhost:8080/custom-google-callback"
     });
 
     expect(googleAuthClient.exchangeAuthorizationCode).toHaveBeenCalledWith({
       authorizationCode: "auth-code",
-      redirectUri: "http://localhost:4000/custom-google-callback"
+      redirectUri: "http://localhost:8080/custom-google-callback"
     });
     expect(userRepository.updateGoogleIdentityById).toHaveBeenCalledWith({
       userId: "user-2",
@@ -188,7 +188,7 @@ describe("GoogleAuthClient", () => {
     const client = new GoogleAuthClient();
     const result = await client.exchangeAuthorizationCode({
       authorizationCode: "auth-code",
-      redirectUri: "http://localhost:4000/auth/google/callback"
+      redirectUri: "http://localhost:8080/auth/google/callback"
     });
 
     expect(result).toEqual({ idToken: "id-token" });
@@ -205,7 +205,7 @@ describe("GoogleAuthClient", () => {
     await expect(
       client.exchangeAuthorizationCode({
         authorizationCode: "auth-code",
-        redirectUri: "http://localhost:4000/auth/google/callback"
+        redirectUri: "http://localhost:8080/auth/google/callback"
       })
     ).rejects.toEqual(new AppError("Google authentication failed", 401));
   });
@@ -221,7 +221,7 @@ describe("GoogleAuthClient", () => {
     await expect(
       client.exchangeAuthorizationCode({
         authorizationCode: "auth-code",
-        redirectUri: "http://localhost:4000/auth/google/callback"
+        redirectUri: "http://localhost:8080/auth/google/callback"
       })
     ).rejects.toEqual(new AppError("Google authentication failed", 401));
   });


### PR DESCRIPTION
## Issues

Closes #

## Summary

Standardizes local runtime defaults to port 8080 and aligns related docs/tests so local startup and OAuth callback expectations remain consistent.

## Changes

- Updated default/local port references from 4000 to 8080 in configuration and examples.
- Updated Google redirect URI defaults to use localhost:8080.
- Updated test env defaults and auth-related test expectations to match 8080.
- Updated development and environment documentation defaults to 8080.

## Verification

- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npx prisma validate`
- [x] Relevant endpoint checks completed

## Checklist

- [x] No secrets were added
- [x] README and docs updated (if needed)
- [x] Backward compatibility considered
